### PR TITLE
Addition of IDs when inserting admin and user roles 

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -778,22 +778,27 @@ func main() {
 	if _, err := controllerManager.Account("admin"); err == manager.ErrAccountDoesNotExist {
 		// create roles
 		r := &shipyard.Role{
+			ID: "0",
 			Name: "admin",
-		}
-		ru := &shipyard.Role{
-			Name: "user",
 		}
 		if err := controllerManager.SaveRole(r); err != nil {
 			logger.Fatal(err)
 		}
+                logger.Infof("created the admin role")
+                ru := &shipyard.Role{
+			ID: "1",
+                        Name: "user",
+                }
 		if err := controllerManager.SaveRole(ru); err != nil {
 			logger.Fatal(err)
 		}
+                logger.Infof("created the user role")
 		role, err := controllerManager.Role(r.Name)
 		if err != nil {
 			logger.Fatal(err)
 		}
 		acct := &shipyard.Account{
+			ID: "0",
 			Username: "admin",
 			Password: "shipyard",
 			Role:     role,

--- a/controller/main.go
+++ b/controller/main.go
@@ -778,27 +778,27 @@ func main() {
 	if _, err := controllerManager.Account("admin"); err == manager.ErrAccountDoesNotExist {
 		// create roles
 		r := &shipyard.Role{
-			ID: "0",
+			ID:   "0",
 			Name: "admin",
 		}
 		if err := controllerManager.SaveRole(r); err != nil {
 			logger.Fatal(err)
 		}
-                logger.Infof("created the admin role")
-                ru := &shipyard.Role{
-			ID: "1",
-                        Name: "user",
-                }
+		logger.Infof("created the admin role")
+		ru := &shipyard.Role{
+			ID:   "1",
+			Name: "user",
+		}
 		if err := controllerManager.SaveRole(ru); err != nil {
 			logger.Fatal(err)
 		}
-                logger.Infof("created the user role")
+		logger.Infof("created the user role")
 		role, err := controllerManager.Role(r.Name)
 		if err != nil {
 			logger.Fatal(err)
 		}
 		acct := &shipyard.Account{
-			ID: "0",
+			ID:       "0",
 			Username: "admin",
 			Password: "shipyard",
 			Role:     role,


### PR DESCRIPTION
This is to fix issue #357, so now initializing shipyard the first time will create the user role as well.
