### PR TITLE
Registered angular-jwt interceptor for X-Access-Token

### DIFF
--- a/controller/static/app/app.jwt.js
+++ b/controller/static/app/app.jwt.js
@@ -1,0 +1,22 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('shipyard')
+        .config([
+                '$httpProvider',
+                'jwtInterceptorProvider', 
+                function ($httpProvider, jwtInterceptorProvider) {
+                    jwtInterceptorProvider.tokenGetter = ['authtoken', function(authtoken) {
+                        // Temporary solution to get angular-jwt to use our header format
+                        jwtInterceptorProvider.authHeader = "X-Access-Token";
+                        jwtInterceptorProvider.authPrefix = "";
+
+                        return localStorage.getItem('X-Access-Token');
+                    }];
+
+                    $httpProvider.interceptors.push('jwtInterceptor');
+                }
+        ]);
+})();
+

--- a/controller/static/app/app.module.js
+++ b/controller/static/app/app.module.js
@@ -16,7 +16,8 @@
         'angular-flash.service',
         'angular-flash.flash-alert-directive',
         'angles',
-        'ansiToHtml'
+        'ansiToHtml',
+        'angular-jwt'
     ]);
 
     Chart.defaults.global.responsive = true;

--- a/controller/static/app/controllers.js
+++ b/controller/static/app/controllers.js
@@ -6,6 +6,7 @@ angular.module('shipyard.controllers', ['ngCookies'])
             $scope.login = function() {
                 Login.login({username: $scope.username, password: $scope.password}).$promise.then(function(data){
                     authtoken.save($scope.username, data.auth_token);
+                    localStorage.setItem('X-Access-Token', authtoken.get());
                     $window.location.href = '/#/dashboard';
                     $window.location.reload();
                 }, function() {

--- a/controller/static/app/layout/header.controller.js
+++ b/controller/static/app/layout/header.controller.js
@@ -11,6 +11,5 @@
         $scope.template = 'app/layout/header.html';
         $scope.username = authtoken.getUsername();
         $scope.isLoggedIn = authtoken.isLoggedIn();
-        $http.defaults.headers.common['X-Access-Token'] = authtoken.get();
     }
 })()

--- a/controller/static/bower.json
+++ b/controller/static/bower.json
@@ -30,6 +30,7 @@
     "angular-cookies": "~1.2.23",
     "angular-flash": "~0.1.13",
     "angles": "*",
-    "ansi-to-html": "jorgeecardona/ansi-to-html"
+    "ansi-to-html": "jorgeecardona/ansi-to-html",
+    "angular-jwt": "~0.0.6"
   }
 }

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -25,6 +25,7 @@
         <script src="bower_components/angular-loader/angular-loader.min.js"></script>
         <script src="bower_components/angular-resource/angular-resource.min.js"></script>
         <script src="bower_components/angular-cookies/angular-cookies.min.js"></script>
+        <script src="bower_components/angular-jwt/dist/angular-jwt.min.js"></script>
         <script src="bower_components/d3/d3.min.js"></script>
         <script src="bower_components/angular-flash/dist/angular-flash.min.js"></script>
         <script src="bower_components/chartjs/Chart.min.js"></script>
@@ -33,6 +34,7 @@
 
         <!-- Angular app bootstrap -->
         <script src="app/app.module.js"></script>
+        <script src="app/app.jwt.js"></script>
         <script src="app/app.routes.js"></script>
 
         <!-- Layout -->


### PR DESCRIPTION
@ehazlett 
I was having a look to see if we can improve the authentication on the UI in some way.  I thought it'd be good to introduce an interceptor that fires whenever `$http` is called and includes our token.

When doing some research on how folks are doing this in the AngularJS world, JSON Web Tokens (JWT) were recommended.  I've used the `angular-jwt` package anyway, but tweaked it to add the header in the `X-Access-Token` format the Shipyard is currently familiar with.  Perhaps support for JWT on the server side would be handy, as that's token authentication stuff that we can re-use.. and there's a go package for it already.

JWT might also give us the ability to better support user/role based actions, as we can store the username, role and an expiry in the token that the UI can decode and make decisions based upon.

Let me know what you think on this. :smile: 
