### PR TITLE
Fixed typo in html markup on error template

### DIFF
--- a/controller/static/app/layout/error.html
+++ b/controller/static/app/layout/error.html
@@ -1,2 +1,2 @@
 <h2>An error occurred</h2>
-<p>Please try again later.</P
+<p>Please try again later.</p>


### PR DESCRIPTION
Noticed the `<p>` tag on the `error.html` page that I added wasn't closed properly.
