### PR TITLE
LDAP authentication

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -21,37 +21,30 @@ type (
 		Tokens    []*AuthToken `json:"-" gorethink:"tokens"`
 		Roles     []string     `json:"roles,omitempty" gorethink:"roles"`
 	}
+
 	AuthToken struct {
 		Token     string `json:"auth_token,omitempty" gorethink:"auth_token"`
 		UserAgent string `json:"user_agent,omitempty" gorethink:"user_agent"`
 	}
-	Authenticator struct {
-		salt []byte
-	}
+
 	ServiceKey struct {
 		Key         string `json:"key,omitempty" gorethink:"key"`
 		Description string `json:"description,omitempty" gorethink:"description"`
 	}
+
+	Authenticator interface {
+		Authenticate(username, password string) bool
+		GenerateToken() (string, error)
+		IsUpdateSupported() bool
+		Name() string
+	}
 )
 
-func NewAuthenticator(salt string) *Authenticator {
-	return &Authenticator{
-		salt: []byte(salt),
-	}
-}
-
-func (a *Authenticator) Hash(password string) (string, error) {
-	h, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+func Hash(data string) (string, error) {
+	h, err := bcrypt.GenerateFromPassword([]byte(data), bcrypt.DefaultCost)
 	return string(h[:]), err
 }
 
-func (a *Authenticator) Authenticate(password, hash string) bool {
-	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err == nil {
-		return true
-	}
-	return false
-}
-
-func (a *Authenticator) GenerateToken() (string, error) {
-	return a.Hash(time.Now().String())
+func GenerateToken() (string, error) {
+	return Hash(time.Now().String())
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -33,7 +33,7 @@ type (
 	}
 
 	Authenticator interface {
-		Authenticate(username, password string) bool
+		Authenticate(username, password, hash string) (bool, error)
 		GenerateToken() (string, error)
 		IsUpdateSupported() bool
 		Name() string

--- a/auth/builtin/builtin.go
+++ b/auth/builtin/builtin.go
@@ -25,11 +25,11 @@ func (a BuiltinAuthenticator) Name() string {
 	return "builtin"
 }
 
-func (a BuiltinAuthenticator) Authenticate(password, hash string) bool {
+func (a BuiltinAuthenticator) Authenticate(username, password, hash string) (bool, error) {
 	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err == nil {
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 func (a BuiltinAuthenticator) GenerateToken() (string, error) {

--- a/auth/builtin/builtin.go
+++ b/auth/builtin/builtin.go
@@ -1,0 +1,37 @@
+package builtin
+
+import (
+	"code.google.com/p/go.crypto/bcrypt"
+	"github.com/shipyard/shipyard/auth"
+)
+
+type (
+	BuiltinAuthenticator struct {
+		salt []byte
+	}
+)
+
+func NewAuthenticator(salt string) auth.Authenticator {
+	return &BuiltinAuthenticator{
+		salt: []byte(salt),
+	}
+}
+
+func (a BuiltinAuthenticator) IsUpdateSupported() bool {
+	return true
+}
+
+func (a BuiltinAuthenticator) Name() string {
+	return "builtin"
+}
+
+func (a BuiltinAuthenticator) Authenticate(password, hash string) bool {
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err == nil {
+		return true
+	}
+	return false
+}
+
+func (a BuiltinAuthenticator) GenerateToken() (string, error) {
+	return auth.GenerateToken()
+}

--- a/auth/ldap/ldap.go
+++ b/auth/ldap/ldap.go
@@ -18,7 +18,7 @@ type (
 )
 
 func NewAuthenticator(server string, port int, baseDN string, autocreateUsers bool) auth.Authenticator {
-	log.Debugf("Using LDAP authentication: server=%s port=%d baseDN=%s",
+	log.Infof("Using LDAP authentication: server=%s port=%d baseDN=%s",
 		server, port, baseDN)
 	return &LdapAuthenticator{
 		Server:          server,

--- a/auth/ldap/ldap.go
+++ b/auth/ldap/ldap.go
@@ -1,0 +1,60 @@
+package ldap
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/shipyard/shipyard/auth"
+	goldap "gopkg.in/ldap.v1"
+)
+
+type (
+	LdapAuthenticator struct {
+		Server          string
+		Port            int
+		BaseDN          string
+		AutocreateUsers bool
+	}
+)
+
+func NewAuthenticator(server string, port int, baseDN string, autocreateUsers bool) auth.Authenticator {
+	log.Debugf("Using LDAP authentication: server=%s port=%d baseDN=%s",
+		server, port, baseDN)
+	return &LdapAuthenticator{
+		Server:          server,
+		Port:            port,
+		BaseDN:          baseDN,
+		AutocreateUsers: autocreateUsers,
+	}
+}
+
+func (a LdapAuthenticator) Name() string {
+	return "ldap"
+}
+
+func (a LdapAuthenticator) Authenticate(username, password, hash string) (bool, error) {
+	log.Debugf("ldap authentication: username=%s", username)
+	l, err := goldap.Dial("tcp", fmt.Sprintf("%s:%d", a.Server, a.Port))
+	if err != nil {
+		log.Error(err)
+		return false, err
+	}
+	defer l.Close()
+
+	dn := fmt.Sprintf("cn=%s,%s", username, a.BaseDN)
+	if err := l.Bind(dn, password); err != nil {
+		return false, err
+	}
+
+	log.Debugf("ldap authentication successful: username=%s", username)
+
+	return true, nil
+}
+
+func (a LdapAuthenticator) IsUpdateSupported() bool {
+	return false
+}
+
+func (a LdapAuthenticator) GenerateToken() (string, error) {
+	return auth.GenerateToken()
+}

--- a/controller/commands/server.go
+++ b/controller/commands/server.go
@@ -3,6 +3,7 @@ package commands
 import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/shipyard/shipyard/auth/builtin"
 	"github.com/shipyard/shipyard/controller/api"
 	"github.com/shipyard/shipyard/controller/manager"
 	"github.com/shipyard/shipyard/utils"
@@ -39,7 +40,9 @@ func CmdServer(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	controllerManager, err := manager.NewManager(rethinkdbAddr, rethinkdbDatabase, rethinkdbAuthKey, client, disableUsageInfo)
+	authenticator := builtin.NewAuthenticator("defaultshipyard")
+
+	controllerManager, err := manager.NewManager(rethinkdbAddr, rethinkdbDatabase, rethinkdbAuthKey, client, disableUsageInfo, authenticator)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/main.go
+++ b/controller/main.go
@@ -85,6 +85,22 @@ func main() {
 					Name:  "enable-cors",
 					Usage: "enable cors with swarm",
 				},
+				cli.StringFlag{
+					Name:  "ldap-server",
+					Usage: "LDAP server address",
+				},
+				cli.IntFlag{
+					Name:  "ldap-port",
+					Usage: "LDAP server port",
+				},
+				cli.StringFlag{
+					Name:  "ldap-base-dn",
+					Usage: "LDAP server base DN",
+				},
+				cli.BoolFlag{
+					Name:  "ldap-autocreate-users",
+					Usage: "Automatically create a corresponding Shipyard account if missing upon authenticating",
+				},
 				cli.StringSliceFlag{
 					Name:  "auth-whitelist-cidr",
 					Usage: "whitelist CIDR to bypass auth",

--- a/controller/main.go
+++ b/controller/main.go
@@ -92,6 +92,7 @@ func main() {
 				cli.IntFlag{
 					Name:  "ldap-port",
 					Usage: "LDAP server port",
+					Value: 389,
 				},
 				cli.StringFlag{
 					Name:  "ldap-base-dn",

--- a/controller/mock_test/manager_mock.go
+++ b/controller/mock_test/manager_mock.go
@@ -76,8 +76,8 @@ func (m MockManager) Role(name string) (*auth.ACL, error) {
 	return roles[0], err
 }
 
-func (m MockManager) Authenticate(username, password string) bool {
-	return false
+func (m MockManager) Authenticate(username, password string) (bool, error) {
+	return false, nil
 }
 
 func (m MockManager) NewAuthToken(username, userAgent string) (*auth.AuthToken, error) {

--- a/controller/static/app/login/403.html
+++ b/controller/static/app/login/403.html
@@ -1,12 +1,14 @@
 <div style="background-color: rgba(0, 68, 91, 1); position: absolute; top: 0; left: 0; height: 100%; width: 100%; text-align: center;">
 <div style="width: 50%; margin: 0 auto;">
     <h1 style="margin-top: 100px; margin-bottom: 50px; font-family: 'Poiret One', sans-serif; font-size: 72px; color: #ffffff;">shipyard</h1>
-    <div class="ui icon warning large message">
-            <i class="warning icon"></i>
+    <div class="ui warning huge message">
             <div class="content">
                 <div class="header">Access Denied</div>
                 <p>Sorry you do not have access to the specified resource.  Please contact your administrator.</p>
             </div>
+    </div>
+    <div class="row">
+        <div class="ui large label"><a ui-sref="logout" class="item"><i class="sign out icon"></i>Logout</a></div>
     </div>
 </div>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -3,58 +3,42 @@
 Composable Docker Management
 
 
-Shipyard enables multi-host, Docker cluster management.  It uses the [Citadel](https://github.com/citadel/citadel) toolkit for cluster resourcing and scheduling.  Shipyard has been dramatically simiplified and only requires access to the Docker Remote API and a RethinkDB instance.
+Shipyard enables multi-host, Docker cluster management.  It uses [Docker Swarm](https://docs.docker.com/swarm) for cluster resourcing and scheduling.
 
 # Quick Start
 
-## Shipyard Deploy
-Shipyard Deploy will automatically start a Shipyard stack on a desired Docker Engine.
+## Option 1: Shipyard Deploy
+This will launch an entire stack.  It uses [Docker Machine](https://docs.docker.com/machine) and the [Docker CLI](https://docs.docker.com) to create
+a Docker Swarm.  It will then deploy Shipyard to manage the Swarm.  When it is finished,
+Shipyard will be configured to manage the Swarm and be ready to go.
+
+### Quick Deploy using VirtualBox
+
+  Note: you must have VirtualBox installed.
 
 ```
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock shipyard/deploy start
+curl -s https://shipyard-project.com/shipyard-deploy | bash -s
 ```
 
-## Manual
-* Start a data volume instance of RethinkDB:
-```
-docker run -it -d --name shipyard-rethinkdb-data \
-  --entrypoint /bin/bash shipyard/rethinkdb -l
-```
+For full options:
 
-* Start RethinkDB with using the data volume container:
 ```
-docker run -it -P -d --name shipyard-rethinkdb \
-  --volumes-from shipyard-rethinkdb-data shipyard/rethinkdb
+curl -s https://shipyard-project.com/shipyard-deploy | bash -s -- -h
 ```
 
-* Start the Shipyard controller:
-```
-docker run -it -p 8080:8080 -d --name shipyard \
-  --link shipyard-rethinkdb:rethinkdb shipyard/shipyard
-```
-
-You can then use the Shipyard CLI to interact:
-
-* `docker run --rm -it shipyard/shipyard-cli`
-
-This will drop you into a shell with the Shipyard executable.  Use `shipyard login` to login to the Shipyard instance.  Use `shipyard add-engine` to add an engine and get started.  See the [docs](http://shipyard-project.com/docs/quickstart/) for more information.
-
-Use `shipyard help` to see full options.
+## Option 2: Manual Deployment (advanced users)
 
 # Documentation
 Full docs are available at http://shipyard-project.com
 
 # Components
-There are four components to Shipyard:
+There are three components to Shipyard:
 
 ## Controller
 The Shipyard controller talks to a RethinkDB instance for data storage (user accounts, engine addresses, events, etc).  It also serves the API and web interface (see below).  The controller uses Citadel to communicate to each host and handle cluster events.
 
 ## API
 Everything in Shipyard is built around the Shipyard API.  It enables actions such as starting, stopping and inspecting containers, adding and removing engines and more.  It is a very simple RESTful JSON based API.
-
-## CLI
-The Shipyard CLI is a Docker inspired command line interface to a Shipyard cluster.  It has been built from the ground up to support every feature that Shipyard offers.
 
 ## UI
 The Shipyard UI is a web interface to the Shipyard cluster.  It uses the Shipyard API for all interaction.  It is an AngularJS app that is served via the Controller.
@@ -64,7 +48,7 @@ The Shipyard UI is a web interface to the Shipyard cluster.  It uses the Shipyar
 ## Controller
 To get a development environment you will need:
 
-* Go 1.3+
+* Go 1.4+
 * Node.js: (npm for bower to build the Angular frontend)
 
 Run the following:
@@ -75,18 +59,6 @@ Run the following:
 * `cd` into the `static` directory and run `bower install`
 * run `make build` to build the binary
 * run `./controller -h` for options
-
-## CLI
-For CLI hacking you will need:
-
-* Go 1.3+
-
-Run the following:
-
-* install [Godep](https://github.com/tools/godep): `go get github.com/tools/godep`
-* run `make deps` to get the Go dependencies
-* run `make build` to build the binary
-* run `./cli -h` for options 
 
 # License
 Shipyard is licensed under the Apache License, Version 2.0. See LICENSE for full license text.


### PR DESCRIPTION
This enables LDAP authentication.  Docs will be coming before release.  Here is some usage info:

There are 4 new flags to the controller:

```
   --ldap-server         
   --ldap-port "389"            
   --ldap-base-dn               
   --ldap-autocreate-users
```

For a quick test, launch an OpenLDAP server:

```
docker run -d -p 389:389 osixia/openldap
```

Then launch the controller with the following options:

```
--ldap-server <docker-host-ip> --ldap-port 389 --ldap-base-dn="dc=example,dc=org"
```

You should then be able to login to Shipyard using the default username and password from that image (username: `admin` password: `admin`).

This has also been tested on Windows Active Directory.

Note: if you do not specify `--ldap-autocreate-users` you will need to manually create the corresponding user account in Shipyard in order to login.  This is to maintain the role based access.

Closes #324 
