### PR TITLE
Added simple start time to inspect page

### DIFF
--- a/controller/static/app/containers/inspect.html
+++ b/controller/static/app/containers/inspect.html
@@ -72,8 +72,8 @@
                     <div class="floated right aligned right column">
                         <h3 class="ui header">
                             <div class="content">
-                                <div class="header" ng-show="vm.container.State.Running">Started: {{ vm.container.State.StartedAt | date:'medium' }}</div>
-                                <div class="header" ng-hide="vm.container.State.Running">Finished: {{ vm.container.State.FinishedAt | date:'medium' }}</div>
+                                <div class="header" ng-show="vm.container.State.Running">Started {{ vm.container.State.StartedAt | fromCalendar }}</div>
+                                <div class="header" ng-hide="vm.container.State.Running">Finished {{ vm.container.State.FinishedAt | fromCalendar }}</div>
                             </div>
                         </h3>
                     </div>

--- a/controller/static/app/shipyard.filters.js
+++ b/controller/static/app/shipyard.filters.js
@@ -3,7 +3,10 @@
 
     angular
         .module('shipyard.filters', [])
-        .filter('roleDisplay', function() {
+        .filter('roleDisplay', roleDisplay)
+        .filter('fromCalendar', fromCalendar);
+        
+        function roleDisplay() {
             return function(input) {
                 var display = "";
                 var scope = "";
@@ -18,5 +21,11 @@
                 }
                 return parts[0].charAt(0).toUpperCase() + parts[0].slice(1) + " " + scope;
             }
-        })
+        };
+
+        function fromCalendar() {
+            return function(input) {
+                return moment(input).calendar().toLowerCase();
+            }
+        };
 })();

--- a/controller/static/bower.json
+++ b/controller/static/bower.json
@@ -26,7 +26,8 @@
     "angular-base64": "~2.0.4",
     "oboe": "~2.1.1",
     "nvd3": "v1.1.15-beta",
-    "angular-selectize2": "~1.2.1"
+    "angular-selectize2": "~1.2.1",
+    "moment": "~2.10.2"
   },
   "resolutions": {
     "angular": "~1.3.15"

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -12,6 +12,8 @@
         <link rel="stylesheet" type="text/css" class="ui" href="./semantic/dist/semantic.min.css">
         <script src="./semantic/dist/semantic.min.js"></script>
 
+        <script src="./bower_components/moment/moment.js"></script>
+
         <script src="./bower_components/angular/angular.min.js"></script>
         <script src="./bower_components/angular-resource/angular-resource.min.js"></script>
         <script src="./bower_components/angular-sanitize/angular-sanitize.min.js"></script>


### PR DESCRIPTION
![screen shot 2015-05-02 at 17 28 08](https://cloud.githubusercontent.com/assets/8657653/7441833/a6a8b4fc-f0f0-11e4-9474-1c15800d9071.png)

@ehazlett @tombee -- makes it easier to read, could include the original timestamp under it in smaller font

![screen shot 2015-05-02 at 17 57 05](https://cloud.githubusercontent.com/assets/8657653/7441914/b6a21f70-f0f4-11e4-861e-1dfc57d6a91c.png)

edit - http://momentjs.com/docs/#/displaying/calendar-time/
