### PR TITLE
[wip] Various refactoring of static resources

### DIFF
--- a/controller/static/app/accounts/accounts.html
+++ b/controller/static/app/accounts/accounts.html
@@ -17,77 +17,79 @@
 </div>
 </div>
 
-<div class="two column row">
-    <div class="left floated column">
-        <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
-            <i class="refresh icon"></i> Refresh
-        </div>
-        <div ui-sref="dashboard.addAccount" class="ui small green labeled icon button">
-            <i class="plus icon"></i> Add Account 
-        </div>
-    </div>
-    <div class="right aligned right floated column">
-        <div class="ui small icon input">
-            <input ng-model="tableFilter" placeholder="Search accounts..." reset-field/>
-        </div>
-    </div>
-</div>
-
-<div class="row" ng-show="vm.accounts.length === 0">
-<div class="column">
-    <div class="ui icon message">
-        <i class="info icon"></i>
-        <div class="content">
-            <div class="header">
-                Accounts
+<div class="ui padded grid">
+    <div class="two column row">
+        <div class="left floated column">
+            <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
+                <i class="refresh icon"></i> Refresh
             </div>
-            <p>There are no accounts.</p>
+            <div ui-sref="dashboard.addAccount" class="ui small green labeled icon button">
+                <i class="plus icon"></i> Add Account 
+            </div>
+        </div>
+        <div class="right aligned right floated column">
+            <div class="ui small icon input">
+                <input ng-model="tableFilter" placeholder="Search accounts..." reset-field/>
+            </div>
         </div>
     </div>
-</div>
-</div>
 
-<div class="row" ng-show="filteredAccounts.length>0">
-    <div class="column">
-        <table class="ui sortable celled table" ng-show="vm.accounts">
-            <thead>
-                <tr>
-                    <th>Username</th>
-                    <th>First Name</th>
-                    <th>Last Name</th>
-                    <th>Roles</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr ng-repeat="a in filteredAccounts = (vm.accounts | filter:tableFilter)">
-                    <td>{{a.username}}</td>
-                    <td>{{a.first_name}}</td>
-                    <td>{{a.last_name}}</td>
-                    <td><div ng-repeat="r in a.roles" class="ui horizontal label">{{r|roleDisplay}}</div></td>
-                    <td class="collapsing">
-                        <div ui-sref="dashboard.editAccount({username: a.username})" class="compact ui icon button">
-                            <i class="search icon"></i>
-                        </div>
-                        <div ng-click="vm.showRemoveAccountDialog(a)" class="compact ui icon button red">
-                            <i class="trash icon"></i>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="row" ng-show="vm.accounts.length > 0 && filteredAccounts.length === 0">
-    <div class="column">
-        <div class="ui icon message">
-            <i class="info icon"></i>
-            <div class="content">
-                <div class="header">
-                    Accounts
+    <div class="row" ng-show="vm.accounts.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Accounts
+                    </div>
+                    <p>There are no accounts.</p>
                 </div>
-                <p>No accounts matched your filter query</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="row" ng-show="filteredAccounts.length>0">
+        <div class="column">
+            <table class="ui sortable celled table" ng-show="vm.accounts">
+                <thead>
+                    <tr>
+                        <th>Username</th>
+                        <th>First Name</th>
+                        <th>Last Name</th>
+                        <th>Roles</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="a in filteredAccounts = (vm.accounts | filter:tableFilter)">
+                        <td>{{a.username}}</td>
+                        <td>{{a.first_name}}</td>
+                        <td>{{a.last_name}}</td>
+                        <td><div ng-repeat="r in a.roles" class="ui horizontal label">{{r|roleDisplay}}</div></td>
+                        <td class="collapsing">
+                            <div ui-sref="dashboard.editAccount({username: a.username})" class="compact ui icon button">
+                                <i class="search icon"></i>
+                            </div>
+                            <div ng-click="vm.showRemoveAccountDialog(a)" class="compact ui icon button red">
+                                <i class="trash icon"></i>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="row" ng-show="vm.accounts.length > 0 && filteredAccounts.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Accounts
+                    </div>
+                    <p>No accounts matched your filter query</p>
+                </div>
             </div>
         </div>
     </div>

--- a/controller/static/app/accounts/add.html
+++ b/controller/static/app/accounts/add.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="row">
     <div class="column">
         <div class="ui segment">
@@ -29,6 +30,7 @@
         </div>
     </div>
 </div>
+</div>
 <script>
 $(function(){
     $('.ui.form')
@@ -39,37 +41,37 @@ $(function(){
             username: {
                 identifier : 'username',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a username'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a username'
+                }
                 ]
             },
             firstName: {
                 identifier : 'firstName',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a first name'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a first name'
+                }
                 ]
             },
             lastName: {
                 identifier : 'lastName',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a last name'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a last name'
+                }
                 ]
             },
             password: {
                 identifier : 'password',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a password'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a password'
+                }
                 ]
             }
         });

--- a/controller/static/app/accounts/edit.html
+++ b/controller/static/app/accounts/edit.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="row">
     <div class="column">
         <div class="ui segment">
@@ -25,6 +26,7 @@
         </div>
     </div>
 </div>
+</div>
 <script>
 $(function(){
     $('.ui.form')
@@ -35,19 +37,19 @@ $(function(){
             firstName: {
                 identifier : 'firstName',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a first name'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a first name'
+                }
                 ]
             },
             lastName: {
                 identifier : 'lastName',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a last name'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a last name'
+                }
                 ]
             }
         });

--- a/controller/static/app/containers/config.routes.js
+++ b/controller/static/app/containers/config.routes.js
@@ -14,7 +14,7 @@
                 templateUrl: 'app/containers/containers.html',
                 controller: 'ContainersController',
                 controllerAs: 'vm',
-                authenticate: true,
+                authenticate: true
             })
         .state('dashboard.inspect', {
             url: '^/containers/{id}',

--- a/controller/static/app/containers/containers.html
+++ b/controller/static/app/containers/containers.html
@@ -107,130 +107,131 @@
     </div>
 </div>
 
-<div class="two column row">
-    <div class="left floated column">
-        <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
-            <i class="refresh icon"></i> Refresh
+<div class="ui padded grid">
+    <div class="two column row">
+        <div class="left floated column">
+            <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
+                <i class="refresh icon"></i> Refresh
+            </div>
+            <div ui-sref="dashboard.deploy" class="ui small green labeled icon button">
+                <i class="add icon"></i> Deploy Container
+            </div>
         </div>
-        <div ui-sref="dashboard.deploy" class="ui small green labeled icon button">
-            <i class="add icon"></i> Deploy Container
-        </div>
-    </div>
 
-    <div class="right aligned right floated column">
-        <div class="ui small icon input">
-            <input ng-model="tableFilter" placeholder="Search containers..." reset-field/>
-        </div>
-    </div>
-</div>
-
-
-<div class="row" ng-show="vm.error">
-    <div class="sixteen wide column">
-        <div class="ui error message">
-            <div class="header">Error...</div>
-            <p>{{vm.error}}</p>
-        </div>
-    </div>
-</div>
-
-<div class="row" ng-show="vm.errors.length > 0">
-    <div class="sixteen wide column">
-        <div class="ui error message">
-            <div class="header">Error...</div>
-            <p ng-repeat="e in vm.errors">{{e}}</p>
-        </div>
-    </div>
-</div>
-
-<div class="row" ng-show="vm.containers.length === 0">
-    <div class="column">
-        <div class="ui icon message">
-            <i class="info icon"></i>
-            <div class="content">
-                <div class="header">
-                    Containers
-                </div>
-                <p>There are no containers.</p>
+        <div class="right aligned right floated column">
+            <div class="ui small icon input">
+                <input ng-model="tableFilter" placeholder="Search containers..." reset-field/>
             </div>
         </div>
     </div>
-</div>
 
-<div class="row" ng-show="filteredContainers.length > 0">
-    <div class="column">
-        <table class="ui sortable celled table">
-            <thead>
-                <tr>
-                    <th id="select-all-table-header" class="collapsing">
-                        <div class="ui fitted checkbox" ng-click="vm.checkAll()">
-                            <input type="checkbox" id="all-cb" ng-model="vm.selectedAll">
-                            <label for="all-cb"></label>
-                        </div>
-                    </th>
-                    <th id="container-health-table-header" class="collapsing"><i class="heartbeat icon"></i></th>
-                    <th class="collapsing">Id</th>
-                    <th>Node</th>
-                    <th>Name</th>
-                    <th>Image</th>
-                    <th>Status</th>
-                    <th>Created</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr ng-class="{'active': vm.selected[c.Id].Selected}" ng-repeat="c in filteredContainers = (vm.containers | filter:tableFilter)" jquery>
-                    <td class="collapsing">
-                        <div class="positive ui fitted checkbox">
-                            <input type="checkbox" id="{{$index}}-cb" ng-model="vm.selected[c.Id].Selected">
-                            <label for="{{$index}}-cb"></label>
-                        </div>
-                    </td>
-                    <td>
-                        <i class="circle icon" ng-class="vm.containerStatusText(c) == 'Running' ? 'green' : 'disabled'"></i>
-                        <span class="hidden">{{vm.containerStatusText(c)}}</span>
-                    </td>
-                    <td>{{c.Id | limitTo:12 }}</td>
-                    <td>{{c.Names[0].split('/')[1]}}</td>
-                    <td>{{c.Names[0].split('/')[2]}}</td>
-                    <td>{{c.Image}}</td>
-                    <td>{{c.Status}}</td>
-                    <td>{{c.Created * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
-                    <td class="collapsing">
-                        <div ui-sref="dashboard.inspect({id: c.Id})" class="basic compact blue ui icon button">
-                            <i class="search icon"></i>
-                        </div>
-                        <div class="ui right pointing dropdown">
-                            <div class="basic compact blue ui icon button">
-                                <i class="wrench icon"></i>
-                            </div>
-                            <div class="menu">
-                                <a ng-click="vm.showRestartContainerDialog(c)" class="item"><i class="green refresh icon"></i> Restart</a>
-                                <a ng-click="vm.showStopContainerDialog(c)" class="item"><i class="black stop icon"></i> Stop</a>
-                                <a ng-click="vm.showDestroyContainerDialog(c)" class="item"><i class="red remove icon"></i> Destroy</a>
-                                <a ng-click="vm.showScaleContainerDialog(c)" class="item"><i class="exchange icon"></i> Scale</a>
-                                <a ng-click="vm.showRenameContainerDialog(c)" class="item"><i class="edit icon"></i> Rename</a>
-                                <a ui-sref="dashboard.stats({id: c.Id})" class="item"><i class="bar chart icon"></i> Stats</a>
-                                <a ui-sref="dashboard.exec({id: c.Id})" class="item"><i class="terminal outline icon"></i> Console</a>
-                                <a ui-sref="dashboard.logs({id: c.Id})" class="item"><i class="text file outline icon"></i> Logs</a>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+    <div class="row" ng-show="vm.error">
+        <div class="sixteen wide column">
+            <div class="ui error message">
+                <div class="header">Error...</div>
+                <p>{{vm.error}}</p>
+            </div>
+        </div>
     </div>
-</div>
 
-<div class="row" ng-show="vm.containers.length > 0 && filteredContainers.length === 0">
-    <div class="column">
-        <div class="ui icon message">
-            <i class="info icon"></i>
-            <div class="content">
-                <div class="header">
-                    Containers
+    <div class="row" ng-show="vm.errors.length > 0">
+        <div class="sixteen wide column">
+            <div class="ui error message">
+                <div class="header">Error...</div>
+                <p ng-repeat="e in vm.errors">{{e}}</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="row" ng-show="vm.containers.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Containers
+                    </div>
+                    <p>There are no containers.</p>
                 </div>
-                <p>No containers matched your filter query</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="row" ng-show="filteredContainers.length > 0">
+        <div class="column">
+            <table class="ui sortable celled table">
+                <thead>
+                    <tr>
+                        <th id="select-all-table-header" class="collapsing">
+                            <div class="ui fitted checkbox" ng-click="vm.checkAll()">
+                                <input type="checkbox" id="all-cb" ng-model="vm.selectedAll">
+                                <label for="all-cb"></label>
+                            </div>
+                        </th>
+                        <th id="container-health-table-header" class="collapsing"><i class="heartbeat icon"></i></th>
+                        <th class="collapsing">Id</th>
+                        <th>Node</th>
+                        <th>Name</th>
+                        <th>Image</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-class="{'active': vm.selected[c.Id].Selected}" ng-repeat="c in filteredContainers = (vm.containers | filter:tableFilter)" jquery>
+                        <td class="collapsing">
+                            <div class="positive ui fitted checkbox">
+                                <input type="checkbox" id="{{$index}}-cb" ng-model="vm.selected[c.Id].Selected">
+                                <label for="{{$index}}-cb"></label>
+                            </div>
+                        </td>
+                        <td>
+                            <i class="circle icon" ng-class="vm.containerStatusText(c) == 'Running' ? 'green' : 'disabled'"></i>
+                            <span class="hidden">{{vm.containerStatusText(c)}}</span>
+                        </td>
+                        <td>{{c.Id | limitTo:12 }}</td>
+                        <td>{{c.Names[0].split('/')[1]}}</td>
+                        <td>{{c.Names[0].split('/')[2]}}</td>
+                        <td>{{c.Image}}</td>
+                        <td>{{c.Status}}</td>
+                        <td>{{c.Created * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>
+                        <td class="collapsing">
+                            <div ui-sref="dashboard.inspect({id: c.Id})" class="basic compact blue ui icon button">
+                                <i class="search icon"></i>
+                            </div>
+                            <div class="ui right pointing dropdown">
+                                <div class="basic compact blue ui icon button">
+                                    <i class="wrench icon"></i>
+                                </div>
+                                <div class="menu">
+                                    <a ng-click="vm.showRestartContainerDialog(c)" class="item"><i class="green refresh icon"></i> Restart</a>
+                                    <a ng-click="vm.showStopContainerDialog(c)" class="item"><i class="black stop icon"></i> Stop</a>
+                                    <a ng-click="vm.showDestroyContainerDialog(c)" class="item"><i class="red remove icon"></i> Destroy</a>
+                                    <a ng-click="vm.showScaleContainerDialog(c)" class="item"><i class="exchange icon"></i> Scale</a>
+                                    <a ng-click="vm.showRenameContainerDialog(c)" class="item"><i class="edit icon"></i> Rename</a>
+                                    <a ui-sref="dashboard.stats({id: c.Id})" class="item"><i class="bar chart icon"></i> Stats</a>
+                                    <a ui-sref="dashboard.exec({id: c.Id})" class="item"><i class="terminal outline icon"></i> Console</a>
+                                    <a ui-sref="dashboard.logs({id: c.Id})" class="item"><i class="text file outline icon"></i> Logs</a>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="row" ng-show="vm.containers.length > 0 && filteredContainers.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Containers
+                    </div>
+                    <p>No containers matched your filter query</p>
+                </div>
             </div>
         </div>
     </div>

--- a/controller/static/app/containers/deploy.html
+++ b/controller/static/app/containers/deploy.html
@@ -1,18 +1,7 @@
-<div class="ui padded grid">
-<div class="row" ng-show="vm.deploying" style="text-align: center;">
-    <div class="six wide column">
-        <div class="ui icon message">
-            <i class="notched circle loading icon"></i>
-            <div class="content">
-                <div class="header">
-                    Launching Container
-                </div>
-                <p>We're deploying the image to the Swarm cluster now.</p>
-                <p>Please note that this could take a few minutes, depending on availability and size of the image.</p>
-            </div>
-        </div>
-    </div>
+<div class="ui active inverted dimmer" ng-show="vm.deploying">
+    <div class="ui text loader">Launching Container</div>
 </div>
+<div class="ui padded grid">
 <div class="row" ng-hide="vm.deploying">
     <div class="column">
         <div class="ui bottom attached active tab segment">

--- a/controller/static/app/containers/deploy.html
+++ b/controller/static/app/containers/deploy.html
@@ -1,16 +1,17 @@
+<div class="ui padded grid">
 <div class="row" ng-show="vm.deploying" style="text-align: center;">
-<div class="six wide column">
-    <div class="ui icon message">
-        <i class="notched circle loading icon"></i>
-        <div class="content">
-            <div class="header">
-                Launching Container
+    <div class="six wide column">
+        <div class="ui icon message">
+            <i class="notched circle loading icon"></i>
+            <div class="content">
+                <div class="header">
+                    Launching Container
+                </div>
+                <p>We're deploying the image to the Swarm cluster now.</p>
+                <p>Please note that this could take a few minutes, depending on availability and size of the image.</p>
             </div>
-            <p>We're deploying the image to the Swarm cluster now.</p>
-            <p>Please note that this could take a few minutes, depending on availability and size of the image.</p>
         </div>
     </div>
-</div>
 </div>
 <div class="row" ng-hide="vm.deploying">
     <div class="column">
@@ -129,10 +130,10 @@
                             <div class="fields">
                                 <div class="seven wide field">
                                     <label>Container</label>
-                                        <select name="containerToLink" ng-model="vm.containerToLink" class="ui search fluid dropdown">
-                                            <option value="">Container Name</option>
-                                            <option ng-repeat="c in vm.containerLinkNames" value="{{c}}">{{c}}</option>
-                                        </select>
+                                    <select name="containerToLink" ng-model="vm.containerToLink" class="ui search fluid dropdown">
+                                        <option value="">Container Name</option>
+                                        <option ng-repeat="c in vm.containerLinkNames" value="{{c}}">{{c}}</option>
+                                    </select>
                                 </div>
                                 <div class="eight wide field">
                                     <label>Alias</label>
@@ -191,8 +192,8 @@
                                     </dropdown>
                                 </div>
                                 <div class="five wide field">
-                                <label>Value</label>
-                                <input name="constraintValue" class="input" type="text" ng-model="vm.constraintValue" placeholder="ssd"></input>
+                                    <label>Value</label>
+                                    <input name="constraintValue" class="input" type="text" ng-model="vm.constraintValue" placeholder="ssd"></input>
                                 </div>
                                 <div class="one wide field">
                                     <label>&nbsp;</label>
@@ -313,6 +314,7 @@
             </div>
         </div>
     </div>
+</div>
 </div>
 <script>
 $(function(){

--- a/controller/static/app/containers/deploy.html
+++ b/controller/static/app/containers/deploy.html
@@ -40,7 +40,7 @@
                                                 <li><i>namespace</i> is an optional <b>namespace</b> to help organize and avoid image name collisions</li>
                                                 <li><i>image-name</i> is the <b>image name</b> that identifies the image that you wish to deploy</li>
                                             </ul>
-                                            <p>When the registry is omitted, Docker will make the assumption that you wish to deploy an image from the Official Docker Hub.  If both the registry and the namespace are omitted, then Docker will assume that you wish to deploy an image from the selection of official Docker images in the Docker Library</p>
+                                            <p>When the registry is omitted, Docker will make the assumption that you wish to deploy an image from the <a href="https://registry.hub.docker.com/" target="_blank">Official Docker Hub</a>.  If both the registry and the namespace are omitted, then Docker will assume that you wish to deploy an image from the selection of official Docker images in the Docker Library</p>
                                         </div>
                                     </label>
                                     <div class="ui corner labeled input">
@@ -331,7 +331,14 @@ $(function(){
             },
         });
 
-    $('.help.circle.icon').popup({inline: true});
+    $('.help.circle.icon').popup({
+        inline: true,
+        hoverable: true,
+        delay: {
+            show: 150,
+            hide: 400
+        }
+    });
     $('.ui.dropdown').dropdown();
-});
+    });
 </script>

--- a/controller/static/app/containers/exec.html
+++ b/controller/static/app/containers/exec.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <!-- this needs to be inlined so it does not conflict with the semantic "terminal" names -->
 <div class="two column row">
     <div class="left floated column">
@@ -19,4 +20,5 @@
             <div id="container-terminal"></div>
         </div>
     </div>
+</div>
 </div>

--- a/controller/static/app/containers/inspect.html
+++ b/controller/static/app/containers/inspect.html
@@ -55,186 +55,188 @@
     </div>
 </div>
 
-<div class="row">
-    <div class="column">
-        <div class="ui segment page" ng-class="{'green': vm.container.State.Running, 'red': !vm.container.State.Running}">
-            <div class= "ui grid">
-                <div class="two column row">
-                    <div class="column">
-                        <h3 class="ui header">
-                            <div class="content">
-                                <i class="ui circle icon" ng-class="{'green': vm.container.State.Running, 'red': !vm.container.State.Running}"></i>
-                                {{ vm.container.Name.split("/")[1] }}
-                                <div class="sub header">{{ vm.container.Config.Image }}</div>
-                            </div>
-                        </h3>
+<div class="ui padded grid">
+    <div class="row">
+        <div class="column">
+            <div class="ui segment page" ng-class="{'green': vm.container.State.Running, 'red': !vm.container.State.Running}">
+                <div class= "ui grid">
+                    <div class="two column row">
+                        <div class="column">
+                            <h3 class="ui header">
+                                <div class="content">
+                                    <i class="ui circle icon" ng-class="{'green': vm.container.State.Running, 'red': !vm.container.State.Running}"></i>
+                                    {{ vm.container.Name.split("/")[1] }}
+                                    <div class="sub header">{{ vm.container.Config.Image }}</div>
+                                </div>
+                            </h3>
+                        </div>
+                        <div class="floated right aligned right column">
+                            <h3 class="ui header">
+                                <div class="content">
+                                    <div class="header" ng-show="vm.container.State.Running">Started {{ vm.container.State.StartedAt | fromCalendar }}</div>
+                                    <div class="header" ng-hide="vm.container.State.Running">Finished {{ vm.container.State.FinishedAt | fromCalendar }}</div>
+                                </div>
+                            </h3>
+                        </div>
                     </div>
-                    <div class="floated right aligned right column">
-                        <h3 class="ui header">
-                            <div class="content">
-                                <div class="header" ng-show="vm.container.State.Running">Started {{ vm.container.State.StartedAt | fromCalendar }}</div>
-                                <div class="header" ng-hide="vm.container.State.Running">Finished {{ vm.container.State.FinishedAt | fromCalendar }}</div>
-                            </div>
-                        </h3>
-                    </div>
-                </div>
 
-                <div class="row">
-                    <div class="column">
-                        <div ng-click="vm.showStopContainerDialog()" class="ui small labeled icon button">
-                            <i class="stop icon"></i> Stop 
-                        </div>
-                        <div ng-click="vm.showRestartContainerDialog()" class="ui small green labeled icon button">
-                            <i class="refresh icon"></i> Restart 
-                        </div>
-                        <div ng-click="vm.showDestroyContainerDialog()" class="ui small red labeled icon button">
-                            <i class="delete icon"></i> Destroy 
-                        </div>
-                        <div ui-sref="dashboard.stats({id: vm.container.Id})" class="ui small orange labeled icon button">
-                            <i class="bar chart icon"></i> Stats
-                        </div>
-                        <div ui-sref="dashboard.logs({id: vm.container.Id})" class="ui small purple labeled icon button">
-                            <i class="file icon"></i> Logs 
-                        </div>
-                        <div ui-sref="dashboard.exec({id: vm.container.Id})" class="ui small labeled icon button">
-                            <i class="terminal icon"></i> Console
-                        </div>
-                    </div>
-                </div>
-                <div class="three column row">
-                    <div class="column">
-                        <h4 class="ui dividing header">Container Configuration</h4>
-                        <div class="ui two column grid">
-                            <div class="column">
-                                <div class="content">
-                                    <span class="header"><b>Container ID</b></span>
-                                    <div class="description">{{ vm.container.Id | limitTo:12 }}</div>
-                                </div>
+                    <div class="row">
+                        <div class="column">
+                            <div ng-click="vm.showStopContainerDialog()" class="ui small labeled icon button">
+                                <i class="stop icon"></i> Stop 
                             </div>
-                            <div class="column">
-                                <div class="content">
-                                    <span class="header"><b>Command</b></span>
-                                    <pre class="logs">{{ vm.container.Config.Cmd.join(" ") }}</pre>
-                                </div>
+                            <div ng-click="vm.showRestartContainerDialog()" class="ui small green labeled icon button">
+                                <i class="refresh icon"></i> Restart 
                             </div>
-                            <div class="column">
-                                <div class="content">
-                                    <span class="header"><b>Hostname</b></span>
-                                    <div class="description">{{ vm.container.Config.Hostname }}</div>
-                                </div>
+                            <div ng-click="vm.showDestroyContainerDialog()" class="ui small red labeled icon button">
+                                <i class="delete icon"></i> Destroy 
                             </div>
-                            <div class="column">
-                                <div class="content">
-                                    <span class="header"><b>Domain Name</b></span>
-                                    <div class="description">{{ vm.container.Config.Domainname || "N/A" }}</div>
-                                </div>
+                            <div ui-sref="dashboard.stats({id: vm.container.Id})" class="ui small orange labeled icon button">
+                                <i class="bar chart icon"></i> Stats
                             </div>
-                        </div>
-                        <h4 class="ui dividing header">Port Configuration</h4>
-                        <div class="ui divided list" ng-show="vm.container.NetworkSettings.Ports"> 
-                            <div class="item" ng-repeat="(k, values) in vm.container.NetworkSettings.Ports">
-                                <div ng-show="values.length === 0 || values == null"><div class="ui horizontal label">Internal</div> {{ k }}</div>
-                                <div class="content" ng-repeat="v in values">
-                                    <div><div class="ui blue horizontal label">Exposed</div> {{ v.HostIp }}:{{ v.HostPort }} &#8594; {{ k }}</div>
-                                </div>
+                            <div ui-sref="dashboard.logs({id: vm.container.Id})" class="ui small purple labeled icon button">
+                                <i class="file icon"></i> Logs 
+                            </div>
+                            <div ui-sref="dashboard.exec({id: vm.container.Id})" class="ui small labeled icon button">
+                                <i class="terminal icon"></i> Console
                             </div>
                         </div>
                     </div>
-                    <div class="column">
-                        <h4 class="ui dividing header">Swarm Node</h4>
-                        <div class="ui two column grid">
-                            <div class="column">
-                                <div class="ui compact">
-                                    <span class="header"><b>Name</b></span>
-                                    <div class="description">{{ vm.container.Node.Name }}</div>
+                    <div class="three column row">
+                        <div class="column">
+                            <h4 class="ui dividing header">Container Configuration</h4>
+                            <div class="ui two column grid">
+                                <div class="column">
+                                    <div class="content">
+                                        <span class="header"><b>Container ID</b></span>
+                                        <div class="description">{{ vm.container.Id | limitTo:12 }}</div>
+                                    </div>
+                                </div>
+                                <div class="column">
+                                    <div class="content">
+                                        <span class="header"><b>Command</b></span>
+                                        <pre class="logs">{{ vm.container.Config.Cmd.join(" ") }}</pre>
+                                    </div>
+                                </div>
+                                <div class="column">
+                                    <div class="content">
+                                        <span class="header"><b>Hostname</b></span>
+                                        <div class="description">{{ vm.container.Config.Hostname }}</div>
+                                    </div>
+                                </div>
+                                <div class="column">
+                                    <div class="content">
+                                        <span class="header"><b>Domain Name</b></span>
+                                        <div class="description">{{ vm.container.Config.Domainname || "N/A" }}</div>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="column">
-                                <div class="ui compact">
-                                    <span class="header"><b>Host</b></span>
-                                    <div class="description">{{ vm.container.Node.Addr }}</div>
-                                </div>
-                            </div>
-                            <div class="column">
-                                <div class="ui compact">
-                                    <span class="header"><b>CPUs</b></span>
-                                    <div class="description">{{ vm.container.Node.Cpus || "&infin;" }}</div>
-                                </div>
-                            </div>
-                            <div class="column">
-                                <div class="ui compact">
-                                    <span class="header"><b>Memory</b></span>
-                                    <div class="description">{{ (vm.container.Node.Memory / 1024 / 1024 | number:0) || "&infin;" }} MB</div>
+                            <h4 class="ui dividing header">Port Configuration</h4>
+                            <div class="ui divided list" ng-show="vm.container.NetworkSettings.Ports"> 
+                                <div class="item" ng-repeat="(k, values) in vm.container.NetworkSettings.Ports">
+                                    <div ng-show="values.length === 0 || values == null"><div class="ui horizontal label">Internal</div> {{ k }}</div>
+                                    <div class="content" ng-repeat="v in values">
+                                        <div><div class="ui blue horizontal label">Exposed</div> {{ v.HostIp }}:{{ v.HostPort }} &#8594; {{ k }}</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="column">
-                        <h4 class="ui dividing header">Environment</h4>
-                        <div ng-show="vm.container.Config.Env.length === 0">
-                            <div>No environment variables configured</div>
+                        <div class="column">
+                            <h4 class="ui dividing header">Swarm Node</h4>
+                            <div class="ui two column grid">
+                                <div class="column">
+                                    <div class="ui compact">
+                                        <span class="header"><b>Name</b></span>
+                                        <div class="description">{{ vm.container.Node.Name }}</div>
+                                    </div>
+                                </div>
+                                <div class="column">
+                                    <div class="ui compact">
+                                        <span class="header"><b>Host</b></span>
+                                        <div class="description">{{ vm.container.Node.Addr }}</div>
+                                    </div>
+                                </div>
+                                <div class="column">
+                                    <div class="ui compact">
+                                        <span class="header"><b>CPUs</b></span>
+                                        <div class="description">{{ vm.container.Node.Cpus || "&infin;" }}</div>
+                                    </div>
+                                </div>
+                                <div class="column">
+                                    <div class="ui compact">
+                                        <span class="header"><b>Memory</b></span>
+                                        <div class="description">{{ (vm.container.Node.Memory / 1024 / 1024 | number:0) || "&infin;" }} MB</div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div class="item" ng-repeat="e in vm.container.Config.Env">
-                            <pre class="logs">{{ e }}</pre>
+                        <div class="column">
+                            <h4 class="ui dividing header">Environment</h4>
+                            <div ng-show="vm.container.Config.Env.length === 0">
+                                <div>No environment variables configured</div>
+                            </div>
+                            <div class="item" ng-repeat="e in vm.container.Config.Env">
+                                <pre class="logs">{{ e }}</pre>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="row" ng-show="vm.links.length>0">
-                    <div class="column">
-                        <h4 class="ui dividing header">Container Links</h4>
-                        <table class="ui sortable celled table">
-                            <thead>
-                                <tr>
-                                    <th>Container Name</th>
-                                    <th>Link Name</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr ng-repeat="v in vm.links">
-                                    <td>{{v.container}}</td>
-                                    <td>{{v.link}}</td>
-                                </tr>
-                        </table>
+                    <div class="row" ng-show="vm.links.length>0">
+                        <div class="column">
+                            <h4 class="ui dividing header">Container Links</h4>
+                            <table class="ui sortable celled table">
+                                <thead>
+                                    <tr>
+                                        <th>Container Name</th>
+                                        <th>Link Name</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="v in vm.links">
+                                        <td>{{v.container}}</td>
+                                        <td>{{v.link}}</td>
+                                    </tr>
+                            </table>
+                        </div>
                     </div>
-                </div>
-                <div class="row" ng-hide="vm.isEmptyObject(vm.container.Volumes)">
-                    <div class="column">
-                        <h4 class="ui dividing header">Volume</h4>
-                        <table class="ui sortable celled table">
-                            <thead>
-                                <tr>
-                                    <th>Volume</th>
-                                    <th>Host Path</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr ng-repeat="(k, v) in vm.container.Volumes">
-                                    <td>{{k}}</td>
-                                    <td>{{v}}</td>
-                                </tr>
-                            </tbody>
-                        </table>
+                    <div class="row" ng-hide="vm.isEmptyObject(vm.container.Volumes)">
+                        <div class="column">
+                            <h4 class="ui dividing header">Volume</h4>
+                            <table class="ui sortable celled table">
+                                <thead>
+                                    <tr>
+                                        <th>Volume</th>
+                                        <th>Host Path</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="(k, v) in vm.container.Volumes">
+                                        <td>{{k}}</td>
+                                        <td>{{v}}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
-                </div>
-                <div class="row" ng-show="vm.top">
-                    <div class="column">
-                        <h4 class="ui dividing header">Processes</h4>
-                        <table id="toptable" class="ui sortable celled table">
-                            <thead>
-                                <tr>
-                                    <th ng-repeat="t in vm.top.Titles">{{ t }}</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr ng-repeat="r in vm.top.Processes">
-                                    <td ng-repeat="c in r">
-                                        {{ c }}
-                                        <script>
+                    <div class="row" ng-show="vm.top">
+                        <div class="column">
+                            <h4 class="ui dividing header">Processes</h4>
+                            <table id="toptable" class="ui sortable celled table">
+                                <thead>
+                                    <tr>
+                                        <th ng-repeat="t in vm.top.Titles">{{ t }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="r in vm.top.Processes">
+                                        <td ng-repeat="c in r">
+                                            {{ c }}
+                                            <script>
 $('.ui.sortable.celled.table').tablesort();
-                                        </script>
-                                    </td>
-                                </tr>
-                        </table>
+                                            </script>
+                                        </td>
+                                    </tr>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/controller/static/app/containers/logs.html
+++ b/controller/static/app/containers/logs.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="row" ng-hide="vm.logs">
     <div class="column">
         <div class="ui icon message">
@@ -12,12 +13,12 @@
     </div>
 </div>
 <div class="row" ng-show="vm.logs">
-<div class="column">
-    <div class="ui segment page" > 
-        <h4 class="dividing header">Container: {{ vm.id | limitTo:12 }}</h2>
-        <pre ng-bind-html="vm.logs" class="logs"> 
-        </pre>
+    <div class="column">
+        <div class="ui segment page" > 
+            <h4 class="dividing header">Container: {{ vm.id | limitTo:12 }}</h2>
+            <pre ng-bind-html="vm.logs" class="logs"> 
+            </pre>
+        </div>
     </div>
 </div>
 </div>
-

--- a/controller/static/app/containers/stats.html
+++ b/controller/static/app/containers/stats.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="two column row">
     <div class="left floated column">
         <h2 class="ui header">
@@ -20,23 +21,24 @@
 </div>
 
 <div class="row">
-<div class="column">
-    <div class="ui segment chart" > 
-        <h3 class="ui header">CPU</h3>
-        <div id='graphCpuStats' class='chart half with-transitions'>
-            <svg></svg>
+    <div class="column">
+        <div class="ui segment chart" > 
+            <h3 class="ui header">CPU</h3>
+            <div id='graphCpuStats' class='chart half with-transitions'>
+                <svg></svg>
+            </div>
         </div>
-    </div>
-    <div class="ui segment chart" > 
-        <h3 class="ui header">Memory</h3>
-        <div id='graphMemoryStats' class='chart half with-transitions'>
-            <svg></svg>
+        <div class="ui segment chart" > 
+            <h3 class="ui header">Memory</h3>
+            <div id='graphMemoryStats' class='chart half with-transitions'>
+                <svg></svg>
+            </div>
         </div>
-    </div>
-    <div class="ui segment chart" > 
-        <h3 class="ui header">Network</h3>
-        <div id='graphNetStats' class='chart half with-transitions'>
-            <svg></svg>
+        <div class="ui segment chart" > 
+            <h3 class="ui header">Network</h3>
+            <div id='graphNetStats' class='chart half with-transitions'>
+                <svg></svg>
+            </div>
         </div>
     </div>
 </div>

--- a/controller/static/app/events/events.html
+++ b/controller/static/app/events/events.html
@@ -1,89 +1,91 @@
 <div id="clear-modal" class="ui small modal transition">
-<i class="close icon"></i>
-<div class="header">
-    Clear Events
-</div>
-<div class="content">
-    <p>Are you sure you want to clear all events?</p>
-</div>
-<div class="actions">
-    <div class="ui negative button">
-        No
+    <i class="close icon"></i>
+    <div class="header">
+        Clear Events
     </div>
-    <div ng-click="vm.clearEvents()" class="ui positive right labeled icon button">
-        Yes
-        <i class="checkmark icon"></i>
+    <div class="content">
+        <p>Are you sure you want to clear all events?</p>
     </div>
-</div>
-</div>
-<div class="two column row">
-    <div class="left floated column">
-        <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
-            <i class="refresh icon"></i> Refresh
+    <div class="actions">
+        <div class="ui negative button">
+            No
         </div>
-        <div ng-click="vm.showClearEventsDialog()" class="ui small red labeled icon button">
-            <i class="trash icon"></i> Clear Events
-        </div>
-    </div>
-    <div class="right aligned right floated column">
-        <div class="ui small icon input">
-            <input ng-model="tableFilter" placeholder="Search events..." reset-field/>
+        <div ng-click="vm.clearEvents()" class="ui positive right labeled icon button">
+            Yes
+            <i class="checkmark icon"></i>
         </div>
     </div>
 </div>
-
-<div class="row" ng-show="vm.events.length === 0">
-<div class="column">
-    <div class="ui icon message">
-        <i class="info icon"></i>
-        <div class="content">
-            <div class="header">
-                Events
+<div class="ui padded grid">
+    <div class="two column row">
+        <div class="left floated column">
+            <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
+                <i class="refresh icon"></i> Refresh
             </div>
-            <p>There are no events recorded.</p>
+            <div ng-click="vm.showClearEventsDialog()" class="ui small red labeled icon button">
+                <i class="trash icon"></i> Clear Events
+            </div>
+        </div>
+        <div class="right aligned right floated column">
+            <div class="ui small icon input">
+                <input ng-model="tableFilter" placeholder="Search events..." reset-field/>
+            </div>
         </div>
     </div>
-</div>
-</div>
 
-<div class="row" ng-show="filteredEvents.length > 0">
-    <div class="column">
-        <table class="ui sortable celled table" ng-show="vm.events">
-            <thead>
-                <tr>
-                    <th>Time</th>
-                    <th>User</th>
-                    <th>Type</th>
-                    <th>Message</th>
-                    <th>Container</th>
-                    <th>Node</th>
-                    <th>Tags</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr ng-repeat="e in filteredEvents = (vm.events | filter:tableFilter)">
-                    <td>{{e.time}}</td>
-                    <td>{{e.username}}</td>
-                    <td>{{e.type}}</td>
-                    <td>{{e.message}}</td>
-                    <td>{{e.container.id | limitTo:8}}</td>
-                    <td>{{e.engine.id}}</td>
-                    <td>{{e.tags.join(', ')}}</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="row" ng-show="vm.events.length > 0 && filteredEvents.length === 0">
-    <div class="column">
-        <div class="ui icon message">
-            <i class="info icon"></i>
-            <div class="content">
-                <div class="header">
-                    Events
+    <div class="row" ng-show="vm.events.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Events
+                    </div>
+                    <p>There are no events recorded.</p>
                 </div>
-                <p>No events matched your filter query</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="row" ng-show="filteredEvents.length > 0">
+        <div class="column">
+            <table class="ui sortable celled table" ng-show="vm.events">
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>User</th>
+                        <th>Type</th>
+                        <th>Message</th>
+                        <th>Container</th>
+                        <th>Node</th>
+                        <th>Tags</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="e in filteredEvents = (vm.events | filter:tableFilter)">
+                        <td>{{e.time}}</td>
+                        <td>{{e.username}}</td>
+                        <td>{{e.type}}</td>
+                        <td>{{e.message}}</td>
+                        <td>{{e.container.id | limitTo:8}}</td>
+                        <td>{{e.engine.id}}</td>
+                        <td>{{e.tags.join(', ')}}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="row" ng-show="vm.events.length > 0 && filteredEvents.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Events
+                    </div>
+                    <p>No events matched your filter query</p>
+                </div>
             </div>
         </div>
     </div>

--- a/controller/static/app/help/help.html
+++ b/controller/static/app/help/help.html
@@ -1,11 +1,13 @@
+<div class="ui padded grid">
 <div class="row">
-<div class="column">
-    <div class="ui segment centered page">
-        <h1>Need help? Have a great idea?</h1>
-        <h4>Github</h4>
-        <p>Raise an issue on <a href="https://github.com/shipyard/shipyard/issues" target="_blank">Github</a></p>
-        <h4>IRC Community</h4>
-        <p><a href="http://webchat.freenode.net?channels=%23shipyard&uio=d4" target="_blank">Join us</a> at irc.freenode.net #shipyard</p>
+    <div class="column">
+        <div class="ui segment centered page">
+            <h1>Need help? Have a great idea?</h1>
+            <h4>Github</h4>
+            <p>Raise an issue on <a href="https://github.com/shipyard/shipyard/issues" target="_blank">Github</a></p>
+            <h4>IRC Community</h4>
+            <p><a href="http://webchat.freenode.net?channels=%23shipyard&uio=d4" target="_blank">Join us</a> at irc.freenode.net #shipyard</p>
+        </div>
     </div>
 </div>
 </div>

--- a/controller/static/app/images/images.html
+++ b/controller/static/app/images/images.html
@@ -1,46 +1,47 @@
 <div id="remove-modal" class="ui small modal transition">
-<i class="close icon"></i>
-<div class="header">
-    Remove Image: {{ vm.selectedImage.Id.substring(0,12) }}
-</div>
-<div class="content">
-    <p>Are you sure you want to remove this image?</p>
-</div>
-<div class="actions">
-    <div class="ui negative button">
-        No
+    <i class="close icon"></i>
+    <div class="header">
+        Remove Image: {{ vm.selectedImage.Id.substring(0,12) }}
     </div>
-    <div ng-click="vm.removeImage()" class="ui positive right labeled icon button">
-        Yes
-        <i class="checkmark icon"></i>
+    <div class="content">
+        <p>Are you sure you want to remove this image?</p>
     </div>
-</div>
-</div>
-
-<div id="pull-modal" class="ui small modal transition">
-<i class="close icon"></i>
-<div class="header">
-    Pull Image
-</div>
-<div class="content">
-    <div class="ui form">
-        <div class="field">
-            <label>Name</label>
-            <input type="text" ng-model="vm.pullImageName">
+    <div class="actions">
+        <div class="ui negative button">
+            No
+        </div>
+        <div ng-click="vm.removeImage()" class="ui positive right labeled icon button">
+            Yes
+            <i class="checkmark icon"></i>
         </div>
     </div>
 </div>
-<div class="actions">
-    <div class="ui negative button">
-        No
+
+<div id="pull-modal" class="ui small modal transition">
+    <i class="close icon"></i>
+    <div class="header">
+        Pull Image
     </div>
-    <div ng-click="vm.pullImage()" class="ui positive right labeled icon button">
-        Yes
-        <i class="checkmark icon"></i>
+    <div class="content">
+        <div class="ui form">
+            <div class="field">
+                <label>Name</label>
+                <input type="text" ng-model="vm.pullImageName">
+            </div>
+        </div>
     </div>
-</div>
+    <div class="actions">
+        <div class="ui negative button">
+            No
+        </div>
+        <div ng-click="vm.pullImage()" class="ui positive right labeled icon button">
+            Yes
+            <i class="checkmark icon"></i>
+        </div>
+    </div>
 </div>
 
+<div class="ui padded grid">
 <div class="two column row" ng-hide="vm.pulling">
     <div class="left floated column">
         <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
@@ -58,18 +59,18 @@
 </div>
 
 <div class="row" ng-show="vm.pulling" style="text-align: center;">
-<div class="six wide column">
-    <div class="ui icon message">
-        <i class="notched circle loading icon"></i>
-        <div class="content">
-            <div class="header">
-                Pulling Image: {{vm.pullImageName}}
+    <div class="six wide column">
+        <div class="ui icon message">
+            <i class="notched circle loading icon"></i>
+            <div class="content">
+                <div class="header">
+                    Pulling Image: {{vm.pullImageName}}
+                </div>
+                <p>We're pulling the image to the Swarm cluster now.</p>
+                <p>Please note that this could take a few minutes, depending on availability and size of the image.</p>
             </div>
-            <p>We're pulling the image to the Swarm cluster now.</p>
-            <p>Please note that this could take a few minutes, depending on availability and size of the image.</p>
         </div>
     </div>
-</div>
 </div>
 
 <div class="row" ng-show="vm.error">
@@ -82,17 +83,17 @@
 </div>
 
 <div class="row" ng-show="vm.images.length === 0">
-<div class="column">
-    <div class="ui icon message">
-        <i class="info icon"></i>
-        <div class="content">
-            <div class="header">
-                Images
+    <div class="column">
+        <div class="ui icon message">
+            <i class="info icon"></i>
+            <div class="content">
+                <div class="header">
+                    Images
+                </div>
+                <p>There are no images in the cluster.</p>
             </div>
-            <p>There are no images in the cluster.</p>
         </div>
     </div>
-</div>
 </div>
 
 <div class="row" ng-show="filteredImages.length>0 && !vm.pulling">
@@ -138,6 +139,7 @@
             </div>
         </div>
     </div>
+</div>
 </div>
 
 <script>

--- a/controller/static/app/layout/dashboard.html
+++ b/controller/static/app/layout/dashboard.html
@@ -1,5 +1,3 @@
-<div class="pusher">
-
 <div class="ui fixed inverted main menu">
     <div class="container">
         <a ui-sref="dashboard.containers" class="title item" id="logo">
@@ -41,37 +39,39 @@
     </div>
 </div>
 
-<div class="ui padded grid">
-    <div class="row" ng-show="isLoadingView" style="text-align: center;">
-        <div class="five wide column">
-            <div class="ui icon message">
-                <i class="notched circle loading icon"></i>
-                <div class="content">
-                    <div class="header">
-                        One moment...
-                    </div>
-                    <p>Fetching content...</p>
-                    <div class="status">
-                        <div ng-repeat="m in vm.messages">{{m}}</div>
+<div class="pusher">
+    <div id="menu-bar-spacer"></div>
+    <div class="ui padded grid">
+        <div class="row" ng-show="isLoadingView" style="text-align: center;">
+            <div class="five wide column">
+                <div class="ui icon message">
+                    <i class="notched circle loading icon"></i>
+                    <div class="content">
+                        <div class="header">
+                            One moment...
+                        </div>
+                        <p>Fetching content...</p>
+                        <div class="status">
+                            <div ng-repeat="m in vm.messages">{{m}}</div>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-    <div class="row" ng-hide="isLoadingView">
-        <div class="column">
-            <div ui-view class="ui grid">
+        <div class="row" ng-hide="isLoadingView">
+            <div class="column">
+                <div ui-view class="ui grid">
+                </div>
+            </div>
+        </div>
+        <div class="ui divider"></div>
+        <div class="row">
+            <div class="center aligned column">
+                <p><a href="//shipyard-project.com">shipyard</a> © 2015</p>
+                <a href="//github.com/shipyard"><i class="big black github icon"></i></a>
             </div>
         </div>
     </div>
-    <div class="ui divider"></div>
-    <div class="row">
-        <div class="center aligned column">
-            <p><a href="//shipyard-project.com">shipyard</a> © 2015</p>
-            <a href="//github.com/shipyard"><i class="big black github icon"></i></a>
-        </div>
-    </div>
-</div>
 </div>
 
 <script>

--- a/controller/static/app/layout/dashboard.html
+++ b/controller/static/app/layout/dashboard.html
@@ -40,6 +40,9 @@
 </div>
 
 <div class="pusher">
+    <div class="ui active inverted dimmer" ng-show="isLoadingView">
+        <div class="ui loader"></div>
+    </div>
     <div id="menu-bar-spacer"></div>
     <div id="content" ui-view>
     </div>

--- a/controller/static/app/layout/dashboard.html
+++ b/controller/static/app/layout/dashboard.html
@@ -41,10 +41,7 @@
 
 <div class="pusher">
     <div id="menu-bar-spacer"></div>
-    <div class="ui active inverted dimmer" ng-show="isLoadingView">
-        <div class="ui text loader">{{ loadingMessage || "Loading" }}</div>
-    </div>
-    <div id="content" ng-hide="isLoadingView" ui-view>
+    <div id="content" ui-view>
     </div>
 </div>
 

--- a/controller/static/app/layout/dashboard.html
+++ b/controller/static/app/layout/dashboard.html
@@ -44,15 +44,7 @@
     <div class="ui active inverted dimmer" ng-show="isLoadingView">
         <div class="ui text loader">{{ loadingMessage || "Loading" }}</div>
     </div>
-    <div id="content">
-        <div class="ui padded grid">
-            <div class="row" ng-hide="isLoadingView">
-                <div class="column">
-                    <div ui-view class="ui grid">
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div id="content" ng-hide="isLoadingView" ui-view>
     </div>
 </div>
 

--- a/controller/static/app/layout/dashboard.html
+++ b/controller/static/app/layout/dashboard.html
@@ -1,74 +1,56 @@
 <div class="ui fixed inverted main menu">
-    <div class="container">
-        <a ui-sref="dashboard.containers" class="title item" id="logo">
-            shipyard
-        </a>
-        <a ui-sref="dashboard.containers" ui-sref-active="active" class="title item">
-            <i class="grid layout icon"></i> Containers
-        </a>
-        <a ui-sref="dashboard.images" ui-sref-active="active" class="title item">
-            <i class="disk outline icon"></i> Images
-        </a>
-        <a ui-sref="dashboard.nodes" ui-sref-active="active" class="title item">
-            <i class="sitemap icon"></i> Nodes
-        </a>
-        <a ui-sref="dashboard.registry" ui-sref-active="active" class="title item">
-            <i class="fork icon"></i> Registries
-        </a>
-        <a ui-sref="dashboard.accounts" ui-sref-active="active" class="title item">
-            <i class="user icon"></i> Accounts
-        </a>
-        <a ui-sref="dashboard.events" ui-sref-active="active" class="title item">
-            <i class="browser icon"></i> Events
-        </a>
-        <div class="ui right inverted menu">
-            <div class="ui item">
-                <div class="ui dropdown">
-                    {{ username }} <i class="dropdown icon"></i>
-                    <div class="menu">
-                        <div ui-sref="logout" class="item"><i class="sign out icon"></i>Logout</div>
-                    </div>
+<div class="container">
+    <a ui-sref="dashboard.containers" class="title item" id="logo">
+        shipyard
+    </a>
+    <a ui-sref="dashboard.containers" ui-sref-active="active" class="title item">
+        <i class="grid layout icon"></i> Containers
+    </a>
+    <a ui-sref="dashboard.images" ui-sref-active="active" class="title item">
+        <i class="disk outline icon"></i> Images
+    </a>
+    <a ui-sref="dashboard.nodes" ui-sref-active="active" class="title item">
+        <i class="sitemap icon"></i> Nodes
+    </a>
+    <a ui-sref="dashboard.registry" ui-sref-active="active" class="title item">
+        <i class="fork icon"></i> Registries
+    </a>
+    <a ui-sref="dashboard.accounts" ui-sref-active="active" class="title item">
+        <i class="user icon"></i> Accounts
+    </a>
+    <a ui-sref="dashboard.events" ui-sref-active="active" class="title item">
+        <i class="browser icon"></i> Events
+    </a>
+    <div class="ui right inverted menu">
+        <div class="ui item">
+            <div class="ui dropdown">
+                {{ username }} <i class="dropdown icon"></i>
+                <div class="menu">
+                    <div ui-sref="logout" class="item"><i class="sign out icon"></i>Logout</div>
                 </div>
             </div>
-            <div class="ui item">
-                <a ui-sref="dashboard.help">
-                    <i class="help circle icon"></i>
-                </a>
-            </div>
+        </div>
+        <div class="ui item">
+            <a ui-sref="dashboard.help">
+                <i class="help circle icon"></i>
+            </a>
         </div>
     </div>
+</div>
 </div>
 
 <div class="pusher">
     <div id="menu-bar-spacer"></div>
-    <div class="ui padded grid">
-        <div class="row" ng-show="isLoadingView" style="text-align: center;">
-            <div class="five wide column">
-                <div class="ui icon message">
-                    <i class="notched circle loading icon"></i>
-                    <div class="content">
-                        <div class="header">
-                            One moment...
-                        </div>
-                        <p>Fetching content...</p>
-                        <div class="status">
-                            <div ng-repeat="m in vm.messages">{{m}}</div>
-                        </div>
+    <div class="ui active inverted dimmer" ng-show="isLoadingView">
+        <div class="ui text loader">{{ loadingMessage || "Loading" }}</div>
+    </div>
+    <div id="content">
+        <div class="ui padded grid">
+            <div class="row" ng-hide="isLoadingView">
+                <div class="column">
+                    <div ui-view class="ui grid">
                     </div>
                 </div>
-            </div>
-        </div>
-        <div class="row" ng-hide="isLoadingView">
-            <div class="column">
-                <div ui-view class="ui grid">
-                </div>
-            </div>
-        </div>
-        <div class="ui divider"></div>
-        <div class="row">
-            <div class="center aligned column">
-                <p><a href="//shipyard-project.com">shipyard</a> © 2015</p>
-                <a href="//github.com/shipyard"><i class="big black github icon"></i></a>
             </div>
         </div>
     </div>

--- a/controller/static/app/nodes/nodes.html
+++ b/controller/static/app/nodes/nodes.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="two column row">
     <div class="left floated column">
         <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
@@ -21,17 +22,17 @@
 </div>
 
 <div class="row" ng-show="vm.nodes.length === 0">
-<div class="column">
-    <div class="ui icon message">
-        <i class="info icon"></i>
-        <div class="content">
-            <div class="header">
-                Nodes
+    <div class="column">
+        <div class="ui icon message">
+            <i class="info icon"></i>
+            <div class="content">
+                <div class="header">
+                    Nodes
+                </div>
+                <p>There are no cluster nodes.</p>
             </div>
-            <p>There are no cluster nodes.</p>
         </div>
     </div>
-</div>
 </div>
 
 <div class="row" ng-show="filteredNodes.length>0">
@@ -73,6 +74,7 @@
             </div>
         </div>
     </div>
+</div>
 </div>
 
 <script>

--- a/controller/static/app/registry/addRegistry.html
+++ b/controller/static/app/registry/addRegistry.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="row">
     <div class="column">
         <div class="ui segment">
@@ -17,6 +18,7 @@
         </div>
     </div>
 </div>
+</div>
 <script>
 $(function(){
     $('.ui.form')
@@ -24,19 +26,19 @@ $(function(){
             name: {
                 identifier : 'name',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter a name'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter a name'
+                }
                 ]
             },
             addr: {
                 identifier : 'addr',
                 rules: [
-                    {
-                        type   : 'empty',
-                        prompt : 'Please enter an address'
-                    }
+                {
+                    type   : 'empty',
+                    prompt : 'Please enter an address'
+                }
                 ]
             }
         });

--- a/controller/static/app/registry/registries.html
+++ b/controller/static/app/registry/registries.html
@@ -17,79 +17,81 @@
 </div>
 </div>
 
-<div class="two column row">
-    <div class="left floated column">
-        <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
-            <i class="refresh icon"></i> Refresh 
+<div class="ui padded grid">
+    <div class="two column row">
+        <div class="left floated column">
+            <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
+                <i class="refresh icon"></i> Refresh 
+            </div>
+            <div ui-sref="dashboard.addRegistry" class="ui small green labeled icon button">
+                <i class="plus icon"></i> Add Registry 
+            </div>
         </div>
-        <div ui-sref="dashboard.addRegistry" class="ui small green labeled icon button">
-            <i class="plus icon"></i> Add Registry 
-        </div>
-    </div>
 
-    <div class="right aligned right floated column">
-        <div class="ui small icon input">
-            <input ng-model="tableFilter" placeholder="Search registries..." reset-field/>
-        </div>
-    </div>
-</div>
-
-<div class="row" ng-show="vm.registries.length === 0">
-    <div class="column">
-        <div class="ui icon message">
-            <i class="info icon"></i>
-            <div class="content">
-                <div class="header">
-                    Registries
-                </div>
-                <p>There are no registries.</p>
+        <div class="right aligned right floated column">
+            <div class="ui small icon input">
+                <input ng-model="tableFilter" placeholder="Search registries..." reset-field/>
             </div>
         </div>
     </div>
-</div>
 
-<div class="row" ng-hide="filteredRegistries.length === 0">
-<div class="column">
-<table class="ui sortable celled table">
-    <thead ng-hide="">
-        <tr>
-            <th>Name</th>
-            <th>Address</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr ng-repeat="r in filteredRegistries = (vm.registries | filter:tableFilter)">
-            <td>{{r.name}}</td>
-            <td>{{r.addr}}</td>
-            <td class="collapsing">
-                <div ui-sref="dashboard.inspectRegistry(r)" class="compact ui icon button">
-                    <i class="search icon"></i>
+    <div class="row" ng-show="vm.registries.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Registries
+                    </div>
+                    <p>There are no registries.</p>
                 </div>
-                <div ng-click="vm.showRemoveRegistryDialog(r)" class="compact ui icon button red">
-                    <i class="trash icon"></i>
-                </div>
-            </td>
-        </tr>
-    </tbody>
-</table>
-</div>
-</div>
+            </div>
+        </div>
+    </div>
 
-<div class="row" ng-show="vm.registries.length > 0 && filteredContainers.length === 0">
-    <div class="column">
-        <div class="ui icon message">
-            <i class="info icon"></i>
-            <div class="content">
-                <div class="header">
-                    Registries
+    <div class="row" ng-hide="filteredRegistries.length === 0">
+        <div class="column">
+            <table class="ui sortable celled table">
+                <thead ng-hide="">
+                    <tr>
+                        <th>Name</th>
+                        <th>Address</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr ng-repeat="r in filteredRegistries = (vm.registries | filter:tableFilter)">
+                        <td>{{r.name}}</td>
+                        <td>{{r.addr}}</td>
+                        <td class="collapsing">
+                            <div ui-sref="dashboard.inspectRegistry(r)" class="compact ui icon button">
+                                <i class="search icon"></i>
+                            </div>
+                            <div ng-click="vm.showRemoveRegistryDialog(r)" class="compact ui icon button red">
+                                <i class="trash icon"></i>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="row" ng-show="vm.registries.length > 0 && filteredContainers.length === 0">
+        <div class="column">
+            <div class="ui icon message">
+                <i class="info icon"></i>
+                <div class="content">
+                    <div class="header">
+                        Registries
+                    </div>
+                    <p>No registries matched your filter query</p>
                 </div>
-                <p>No registries matched your filter query</p>
             </div>
         </div>
     </div>
 </div>
 
 <script>
-    $('.ui.sortable.celled.table').tablesort();
+$('.ui.sortable.celled.table').tablesort();
 </script>

--- a/controller/static/app/registry/registry.html
+++ b/controller/static/app/registry/registry.html
@@ -17,6 +17,9 @@
 </div>
 </div>
 
+        <div class="ui padded grid">
+            <div class="row">
+                <div class="column">
 <div class="two column row">
     <div class="left floated column">
         <div ng-click="vm.refresh()" class="ui small blue labeled icon button">
@@ -79,6 +82,9 @@
 </table>
 </div>
 </div>
+                </div>
+            </div>
+        </div>
 
 <script>
     $('.ui.sortable.celled.table').tablesort();

--- a/controller/static/app/registry/repository.html
+++ b/controller/static/app/registry/repository.html
@@ -1,3 +1,4 @@
+<div class="ui padded grid">
 <div class="row">
     <div class="column">
         <div class="ui segment page blue">
@@ -70,4 +71,5 @@
             </div>
         </div>
     </div>
+</div>
 </div>

--- a/controller/static/main.css
+++ b/controller/static/main.css
@@ -10,6 +10,10 @@
     text-transform: none;
 }
 
+#menu-bar-spacer {
+    padding: 20px;
+}
+
 .ui.small.model.transition {
     margin-top: -98px;
 }


### PR DESCRIPTION
I'm working on trying to clean up the parent templates to make them more manageable, and eventually try to remove the warning about the sidebar not being a child of the body element.
- switched to using semantic-ui's own 'loader', as I think it looks pretty sweet
- removed the footer, since I think it probably adds unnecessary noise to the clean interface we're looking for and it doesn't really serve much of a purpose at the moment.  _What do you think?_
- removed grid layout element from parent template, I don't think we should let child pages dictate their own layout without having to conform to a grid layout.  This has caught us both out before I think :smile: 
- clickable links in tool tips
- attempted to make better use of screen real estate on containers page -- finding that heavily padded tables in busy environments don't look great
- increased size of search boxes to be consistent with buttons, and also to make them 'stand out' more
- Switched to use semantic-ui loader when deploying a container
