### PR TITLE
Fix two typos in engines.html

### DIFF
--- a/controller/static/app/engines/engines.html
+++ b/controller/static/app/engines/engines.html
@@ -25,7 +25,7 @@
             <th ng-class="vm.tablesort.semanticHeaderClass('engine.addr')" ng-click="vm.tablesort.sortBy('engine.addr')">Addr</th>
             <th ng-class="vm.tablesort.semanticHeaderClass('engine.labels')" ng-click="vm.tablesort.sortBy('engine.labels')">Labels</th>
             <th ng-class="vm.tablesort.semanticHeaderClass('health.response_time')" ng-click="vm.tablesort.sortBy('health.response_time')">Response Time (ms)</th>
-            <th ng-class="vvm.tablesort.semanticHeaderClass('engine.docker_version')" ng-click="vm.stablesort.sortBy('engine.docker_version')">Docker Version</th>
+            <th ng-class="vm.tablesort.semanticHeaderClass('engine.docker_version')" ng-click="vm.tablesort.sortBy('engine.docker_version')">Docker Version</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Fix two typos: "vvm" -> "vm", "stablesort" -> "tablesort".
