### PR TITLE
Fix incorrect container name on dashboard

### DIFF
--- a/controller/static/app/containers/containers.controller.js
+++ b/controller/static/app/containers/containers.controller.js
@@ -35,6 +35,8 @@
         vm.renameContainer = renameContainer;
         vm.refresh = refresh;
         vm.containerStatusText = containerStatusText;
+		vm.nodeName = nodeName;
+		vm.containerName = containerName;
         vm.checkAll = checkAll;
         vm.clearAll = clearAll;
         vm.destroyAll = destroyAll;
@@ -264,5 +266,36 @@
             }            
             return "Unknown";
         }   
+		
+		function nodeName(container) {
+			// Return only the node name (first component of the shortest container name)
+			var components = shortestContainerName(container).split('/');
+			return components[1];
+		}
+		
+		function containerName(container) {
+			// Remove the node name by returning the last name component of the shortest container name
+			var components = shortestContainerName(container).split('/');
+			return components[components.length-1];
+		}
+		
+		function shortestContainerName(container) {
+			// Distill shortest container name by taking the name with the fewest components
+			// Names with the same number of components are considered in undefined order
+			var shortestName = "";
+			var minComponents = 99;
+			
+			var names = container.Names
+			for(var i=0; i<names.length; i++) {
+				var name = names[i];
+				var numComponents = name.split('/').length
+				if(numComponents < minComponents) {
+					shortestName = name;
+					minComponents = numComponents;
+				}
+			}
+
+			return shortestName;			
+		}
     }
 })();

--- a/controller/static/app/containers/containers.html
+++ b/controller/static/app/containers/containers.html
@@ -103,7 +103,7 @@
 <div id="rename-modal" class="ui small modal transition">
     <i class="close icon"></i>
     <div class="header">
-        Rename Container: {{ vm.selectedContainer.Names[0].split('/')[2] }}
+        Rename Container: {{ vm.containerName(vm.selectedContainer) }}
     </div>
     <div class="content">
         <div class="ui form">
@@ -210,8 +210,8 @@
                             <span class="hidden">{{vm.containerStatusText(c)}}</span>
                         </td>
                         <td>{{c.Id | limitTo:12 }}</td>
-                        <td>{{c.Names[0].split('/')[1]}}</td>
-                        <td>{{c.Names[0].split('/')[2]}}</td>
+                        <td>{{vm.nodeName(c)}}</td>
+                        <td>{{vm.containerName(c)}}</td> 
                         <td>{{c.Image}}</td>
                         <td>{{c.Status}}</td>
                         <td>{{c.Created * 1000 | date:'yyyy-MM-dd HH:mm:ss Z'}}</td>


### PR DESCRIPTION
For containers with links and/or multiple names, Shipyard would display the first name, which was not always the correct one (sometimes it would display the name of the linked container instead). This pull request changes the logic to be closer to what "docker ps" uses when displaying the name.
