### PR TITLE
don't list intermediate images

### DIFF
--- a/controller/static/app/images/images.service.js
+++ b/controller/static/app/images/images.service.js
@@ -10,7 +10,7 @@
             return {
                 list: function() {
                     var promise = $http
-                        .get('/images/json?all=1')
+                        .get('/images/json')
                         .then(function(response) {
                             return response.data;
                         });


### PR DESCRIPTION
#667

get('/images/json?all=1') lists all of intermediate images like this;

```
# docker images -a

REPOSITORY                     TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
<none>                         <none>              06ca28ccc03b        49 minutes ago      172.3 MB
<none>                         <none>              86e83e947593        50 minutes ago      172.3 MB
<none>                         <none>              fea77d2fd61e        6 weeks ago         190.6 MB
<none>                         <none>              2c2557968d48        6 weeks ago         190.6 MB
docker.io/centos               latest              ce20c473cd8a        6 weeks ago         172.3 MB
docker.io/shipyard/shipyard    latest              b41dcda840c8        9 weeks ago         58.7 MB
```

The result of "docker images" is just enough.
