### PR TITLE
network mode support for deploying container

### DIFF
--- a/controller/static/app/containers/deploy.controller.js
+++ b/controller/static/app/containers/deploy.controller.js
@@ -61,6 +61,7 @@
         vm.request = {
             HostConfig: {
                 RestartPolicy: { Name: 'no' },
+                NetworkMode: 'bridge',
                 Links: [],
                 Binds: [],
                 Privileged: false,

--- a/controller/static/app/containers/deploy.html
+++ b/controller/static/app/containers/deploy.html
@@ -244,6 +244,14 @@
                                     <input type="number" ng-model="vm.request.HostConfig.RestartPolicy.MaximumRetryCount" placeholder="Maximum restart count">
                                 </div>
                             </div>
+                            <h5 class="ui dividing header">Network Mode</h5>
+                            <div class="field">
+                                <select class="ui fluid dropdown" default="0" ng-model="vm.request.HostConfig.NetworkMode">
+                                    <option value="bridge">Bridge</option>
+                                    <option value="host">Host</option>
+                                    <option value="none">None</option>
+                                </select>
+                            </div>
                             <h5 class="ui dividing header">Port Configuration</h5>
                             <div class="field">
                                 <div class="ui toggle checkbox">


### PR DESCRIPTION
this makes network mode configurable while deploying container, which is useful for those who want to  
deploy container running in host network mode or none
