### PR TITLE
Fix bug of web-console for docker-1.10.1.

### DIFF
--- a/controller/api/hijack.go
+++ b/controller/api/hijack.go
@@ -87,7 +87,7 @@ func (a *Api) hijack(addr, method, path string, setRawTerminal bool, in io.ReadC
 	}
 
 	req.Header.Set("User-Agent", "Docker-Client")
-	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 	req.Host = addr


### PR DESCRIPTION
I got a problem with using web-console to execute CMD in containers(docker-1.10.1).

Err msg : "Content-Type specified (text/plain) must be 'application/json'".

Because DockerAPI-1.22-"Exec start" require Content-Type('application/json').

https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/
