### PR TITLE
added hostconfig to createContainer Call

### DIFF
--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -250,6 +250,7 @@ func (m DefaultManager) ScaleContainer(id string, numInstances int) ScaleResult 
 			// clear hostname to get a newly generated
 			config.Hostname = ""
 			hostConfig := containerInfo.HostConfig
+			config.HostConfig = *hostConfig // sending hostconfig via the Start-endpoint is deprecated starting with docker-engine 1.12
 			id, err := m.client.CreateContainer(config, "")
 			if err != nil {
 				errChan <- err


### PR DESCRIPTION
... because sending it via startconfig is deprecated and broken in docker swarm
