### PR TITLE
Update deploy.controller.js

### DIFF
--- a/controller/static/app/containers/deploy.controller.js
+++ b/controller/static/app/containers/deploy.controller.js
@@ -254,7 +254,10 @@
                 return;
             }
             vm.deploying = true;
-
+            
+            // Reset Env
+            vm.request.Env = [];
+            
             transformVolumes();
             transformLinks();
             transformEnvVars();


### PR DESCRIPTION
Resetting the request.Env array before continuing. This fixes an error caused with duplicate constraints if the first deploy fails. Perhaps fully resetting the whole request object is a better way to go about it, but I'm not versed enough with the mechanics of this one.
