### PR TITLE
add scale app mutex

### DIFF
--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -256,6 +256,7 @@ func (m DefaultManager) ScaleContainer(id string, numInstances int) ScaleResult 
 			config.HostConfig = *hostConfig // sending hostconfig via the Start-endpoint is deprecated starting with docker-engine 1.12
 
 			lock.Lock()
+			defer lock.Unlock()
 			id, err := m.client.CreateContainer(config, "", nil)
 			if err != nil {
 				errChan <- err
@@ -265,7 +266,6 @@ func (m DefaultManager) ScaleContainer(id string, numInstances int) ScaleResult 
 				errChan <- err
 				return
 			}
-			lock.Unlock()
 			resChan <- id
 		}(i)
 	}


### PR DESCRIPTION
when using shipyard to manage a swarm cluster, scale app will come out an error:

I want my container run alone on the node, so I use the container affinity.  for example a Nginx:
`$ docker run -e  affinity:run!=alone -l run=alone nginx:latest`

there are five nodes in my swarm cluster.

then scale the Nginx container to 5, you can see some container still run go the same node!!! This is because of creating container at the same time, when old request selects a node but not deploy on it, the new request judge the node had not deploy a container so select the node too.
