### PR TITLE
Formatted image sizes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,10 +18,10 @@
     "react": "^15.4.0",
     "react-datetime": "^2.8.3",
     "react-dom": "^15.4.0",
-    "react-router": "^4.0.0-alpha.6",
+    "react-router": "4.0.0-alpha.6",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
-    "reactable": "^0.14.0",
+    "reactable": "^0.14.1",
     "semantic-ui-css": "^2.2.4",
     "semantic-ui-react": "^0.64.3",
     "xterm": "^2.2.3"

--- a/ui/src/components/images/ImageInspectView.js
+++ b/ui/src/components/images/ImageInspectView.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import moment from 'moment';
 
 import { inspectImage, historyImage } from '../../api';
+import { getReadableFileSizeString } from '../../lib';
 
 class ImageInspectView extends React.Component {
   state = {
@@ -114,8 +115,8 @@ class ImageInspectView extends React.Component {
                   <tr><td>Author</td><td>{image.Author}</td></tr>
                   <tr><td>Comment</td><td>{image.Comment}</td></tr>
                   <tr><td>Docker Version</td><td>{image.DockerVersion}</td></tr>
-                  <tr><td>Size</td><td>{image.Size}</td></tr>
-                  <tr><td>Virtual Size</td><td>{image.VirtualSize}</td></tr>
+                  <tr><td>Size</td><td>{getReadableFileSizeString(image.Size)}</td></tr>
+                  <tr><td>Virtual Size</td><td>{getReadableFileSizeString(image.VirtualSize)}</td></tr>
                 </tbody>
               </table>
 

--- a/ui/src/components/images/ImageListView.js
+++ b/ui/src/components/images/ImageListView.js
@@ -5,6 +5,7 @@ import { Table, Tr, Td } from 'reactable';
 import { Link } from 'react-router';
 
 import { listImages } from '../../api';
+import { getReadableFileSizeString } from '../../lib';
 
 class ImageListView extends React.Component {
   state = {
@@ -50,7 +51,7 @@ class ImageListView extends React.Component {
           {new Date(image.Created * 1000).toLocaleString()}
         </Td>
         <Td column="Size">
-          {image.Size}
+          {getReadableFileSizeString(image.Size)}
         </Td>
       </Tr>
     );
@@ -95,7 +96,7 @@ class ImageListView extends React.Component {
             <Table
               ref="table"
               className="ui compact celled unstackable table"
-              sortable
+              sortable={['Repository', 'Tag', 'Image ID', 'Created']}
               filterable={['Repository', 'Tag', 'Image ID', 'Created', 'Size']}
               hideFilterInput
               noDataText="Couldn't find any images"

--- a/ui/src/lib/index.js
+++ b/ui/src/lib/index.js
@@ -24,11 +24,21 @@ export const getUnhandledProps = (Component, props) => {
 
 // FIXME: This is pretty hacky
 export const shortenImageName = (image) => {
-  var splitImage = image.split('@');
+  const splitImage = image.split('@');
   if(splitImage.length > 1) {
-  	var splitSha = splitImage[1].split(':');
+  	const splitSha = splitImage[1].split(':');
     return `${splitImage[0]}@${splitSha[0]}:${splitSha[1].substring(0, 12)}`;
   } else {
   	return image;
   }
+}
+
+export const getReadableFileSizeString = (fileSizeInBytes) => {
+  let i = -1;
+  const byteUnits = [' kB', ' MB', ' GB', ' TB', 'PB', 'EB', 'ZB', 'YB'];
+  do {
+    fileSizeInBytes /= 1024;
+    i++;
+  } while (fileSizeInBytes > 1024);
+  return Math.max(fileSizeInBytes, 0.1).toFixed(1) + byteUnits[i];
 }


### PR DESCRIPTION
- Pinned react-route version: package restructuring in beta 2 is temporarily broken
- Updated reactable to 0.14.1
- Formatted image size on Image List and Image Inspect screens to be human readable
