### PR TITLE
Sort icons for all tables, default sort all tables

### DIFF
--- a/ui/src/components/accounts/AccountListView.js
+++ b/ui/src/components/accounts/AccountListView.js
@@ -37,7 +37,7 @@ class AccountListView extends React.Component {
   renderAccount = (account) => {
     return (
       <Tr key={account.id}>
-        <Td column="Username">
+        <Td column="Username" value={account.username}>
           <Link to={`/accounts/inspect/${account.username}`}>{account.username}</Link>
         </Td>
         <Td column="First Name">{account.first_name}</Td>
@@ -75,8 +75,9 @@ class AccountListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              sortable={["Username", "First Name", "Last Name", "Roles"]}
+              defaultSort={{column: "Username", direction: "asc"}}
               filterable={["Username", "First Name", "Last Name", "Roles"]}
               hideFilterInput
               noDataText="Couldn't find any accounts"

--- a/ui/src/components/containers/ContainerListView.js
+++ b/ui/src/components/containers/ContainerListView.js
@@ -41,11 +41,13 @@ class ContainerListView extends React.Component {
         <Td column="" className="collapsing">
           <Icon fitted className={`circle ${container.Status.indexOf('Up') === 0 ? 'green' : 'red'}`} />
         </Td>
-        <Td column="ID" className="collapsing">
+        <Td column="ID" value={container.Id} className="collapsing">
           <Link to={`/containers/inspect/${container.Id}`}>{container.Id.substring(0, 12)}</Link>
         </Td>
-        <Td column="Image">{shortenImageName(container.Image)}</Td>
-        <Td column="Created" className="collapsing">
+        <Td column="Image" value={container.Image}>
+          {shortenImageName(container.Image)}
+        </Td>
+        <Td column="Created" value={container.Created} className="collapsing">
           {new Date(container.Created * 1000).toLocaleString()}
         </Td>
         <Td column="Name">{container.Names[0]}</Td>
@@ -81,8 +83,9 @@ class ContainerListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              sortable={["ID", "Image", "Created", "Name"]}
+              defaultSort={{column: "Name", direction: "asc"}}
               filterable={["ID", "Image", "Created", "Name"]}
               hideFilterInput
               noDataText="Couldn't find any containers"

--- a/ui/src/components/images/ImageListView.js
+++ b/ui/src/components/images/ImageListView.js
@@ -41,16 +41,16 @@ class ImageListView extends React.Component {
         <Td column="Repository">
           {image.RepoTags[tagIndex].split(':')[0]}
         </Td>
-        <Td column="Tag">
+        <Td column="Tag" value={image.RepoTags[tagIndex].split(':')[1]}>
           <Link to={`/images/inspect/${image.Id}`}>{image.RepoTags[tagIndex].split(':')[1]}</Link>
         </Td>
-        <Td column="Image ID" className="collapsing">
+        <Td column="Image ID" value={image.Id} className="collapsing">
           {image.Id.replace('sha256:', '').substring(0, 12)}
         </Td>
-        <Td column="Created">
+        <Td column="Created" value={image.Created}>
           {new Date(image.Created * 1000).toLocaleString()}
         </Td>
-        <Td column="Size">
+        <Td column="Size" value={image.Size}>
           {getReadableFileSizeString(image.Size)}
         </Td>
       </Tr>
@@ -97,6 +97,7 @@ class ImageListView extends React.Component {
               ref="table"
               className="ui compact celled unstackable table"
               sortable={['Repository', 'Tag', 'Image ID', 'Created']}
+              defaultSort={{column: 'Repository', direction: 'asc'}}
               filterable={['Repository', 'Tag', 'Image ID', 'Created', 'Size']}
               hideFilterInput
               noDataText="Couldn't find any images"

--- a/ui/src/components/networks/NetworkListView.js
+++ b/ui/src/components/networks/NetworkListView.js
@@ -37,7 +37,7 @@ class NetworkListView extends React.Component {
   renderNetwork = (network) => {
     return (
       <Tr key={network.Id}>
-        <Td column="Id" className="collapsing">
+        <Td column="Id" value={network.Id} className="collapsing">
           <Link to={`/networks/inspect/${network.Id}`}>{network.Id.substring(0, 12)}</Link>
         </Td>
         <Td column="Name">{network.Name}</Td>
@@ -75,9 +75,10 @@ class NetworkListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
-              filterable={['ID', 'Name', 'Driver', 'Scope']}
+              className="ui compact celled unstackable table"
+              sortable={['Id', 'Name', 'Driver', 'Scope']}
+              defaultSort={{column: 'Name', direction: 'asc'}}
+              filterable={['Id', 'Name', 'Driver', 'Scope']}
               hideFilterInput
               noDataText="Couldn't find any networks"
             >

--- a/ui/src/components/nodes/NodeInspectView.js
+++ b/ui/src/components/nodes/NodeInspectView.js
@@ -203,10 +203,11 @@ class NodeListView extends React.Component {
                   <input placeholder="Search..." onChange={this.updateFilter}></input>
                 </div>
                 <Table
-                  className="ui compact celled sortable unstackable table"
+                  className="ui compact celled unstackable table"
                   ref="table"
-                  sortable
-                  filterable={['ID', 'Name', 'Image', 'Command']}
+                  sortable={["Service", "ID", "Container ID", "Name", "Image", "Last Status Update"]}
+                  defaultSort={{column: "Name", direction: "asc"}}
+                  filterable={["ID", "Container ID", "Name", "Image"]}
                   hideFilterInput
                   noDataText="Couldn't find any tasks"
                 >

--- a/ui/src/components/nodes/NodeListView.js
+++ b/ui/src/components/nodes/NodeListView.js
@@ -40,11 +40,11 @@ class NodeListView extends React.Component {
         <Td column="" className="collapsing">
           <Icon fitted className={`circle ${node.Status.State === 'ready' ? 'green' : 'red'}`} />
         </Td>
-        <Td column="ID" className="collapsing">
+        <Td column="ID" value={node.ID} className="collapsing">
           <Link to={`/nodes/inspect/${node.ID}`}>{node.ID.substring(0, 12)}</Link>
         </Td>
         <Td column="Hostname">{node.Description.Hostname}</Td>
-        <Td column="OS">
+        <Td column="OS" value={node.Description.Platform.OS+" "+node.Description.Platform.Architecture}>
           <span>{node.Description.Platform.OS} {node.Description.Platform.Architecture}</span>
         </Td>
         <Td column="Engine">{node.Description.Engine.EngineVersion}</Td>
@@ -81,8 +81,9 @@ class NodeListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              sortable={["ID", "Hostname", "OS", "Engine", "Type"]}
+              defaultSort={{column: 'Hostname', direction: 'asc'}}
               filterable={["ID", "Hostname", "OS", "Engine", "Type"]}
               hideFilterInput
               noDataText="Couldn't find any nodes"

--- a/ui/src/components/registries/RegistryInspectView.js
+++ b/ui/src/components/registries/RegistryInspectView.js
@@ -88,8 +88,9 @@ class RegistryInspectView extends React.Component {
           <Grid.Column className="ui sixteen wide basic segment">
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              defaultSort={{column: 'Name', direction: 'asc'}}
+              sortable={["Name", "Tag"]}
               filterable={["Name"]}
               hideFilterInput
               noDataText="Couldn't find any registries"

--- a/ui/src/components/registries/RegistryListView.js
+++ b/ui/src/components/registries/RegistryListView.js
@@ -37,7 +37,7 @@ class RegistryListView extends React.Component {
   renderRow = (registry, tagIndex) => {
     return (
       <Tr key={registry.id}>
-        <Td column="ID" className="collapsing">
+        <Td column="ID" value={registry.id} className="collapsing">
           <Link to={`/registries/inspect/${registry.id}`}>
             {registry.id.substring(0, 8)}
           </Link>
@@ -90,8 +90,9 @@ class RegistryListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              sortable={["ID", "Name", "Address"]}
+              defaultSort={{column: 'Name', direction: 'asc'}}
               filterable={["ID", "Name", "Address"]}
               hideFilterInput
               noDataText="Couldn't find any registries"

--- a/ui/src/components/secrets/SecretListView.js
+++ b/ui/src/components/secrets/SecretListView.js
@@ -37,7 +37,7 @@ class SecretListView extends React.Component {
   renderRow = (secret, tagIndex) => {
     return (
       <Tr key={secret.ID}>
-        <Td column="ID" className="collapsing">
+        <Td column="ID" value={secret.ID} className="collapsing">
           <Link to={`/secrets/inspect/${secret.ID}`}>
             {secret.ID.substring(0, 12)}
           </Link>
@@ -87,8 +87,9 @@ class SecretListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              sortable={["ID", "Name"]}
+              defaultSort={{column: 'Name', direction: 'asc'}}
               filterable={["ID", "Name"]}
               hideFilterInput
               noDataText="Couldn't find any secrets"

--- a/ui/src/components/services/ServiceInspectView.js
+++ b/ui/src/components/services/ServiceInspectView.js
@@ -92,7 +92,7 @@ class ServiceListView extends React.Component {
         <Td column="ID" className="collapsing">
           {t.ID.substring(0, 12)}
         </Td>
-        <Td column="Container ID" className="collapsing">
+        <Td column="Container ID" value={t.Status.ContainerStatus.ContainerID} className="collapsing">
           {
             t.Status.ContainerStatus.ContainerID ?
             <Link to={`/services/inspect/${s.ID}/container/${t.Status.ContainerStatus.ContainerID}`}>{t.Status.ContainerStatus.ContainerID.substring(0, 12)}</Link> :
@@ -105,10 +105,10 @@ class ServiceListView extends React.Component {
         <Td column="Image">
           {shortenImageName(t.Spec.ContainerSpec.Image)}
         </Td>
-        <Td column="Last Status Update" className="collapsing">
+        <Td column="Last Status Update" value={t.Status.Timestamp} className="collapsing">
           {new Date(t.Status.Timestamp).toLocaleString()}
         </Td>
-        <Td column="Node">
+        <Td column="Node" value={this.state.nodes[t.NodeID]}>
           {this.state.nodes[t.NodeID] ? this.state.nodes[t.NodeID].Description.Hostname : null}
         </Td>
       </Tr>
@@ -414,9 +414,10 @@ class ServiceListView extends React.Component {
                 <input placeholder="Search..." onChange={this.updateFilter}></input>
               </div>
               <Table
-                className="ui compact celled sortable unstackable table"
+                className="ui compact celled unstackable table"
                 ref="table"
-                sortable
+                sortable={["ID", "Container ID", "Name", "Image", "Last Status Update", "Node"]}
+                defaultSort={{column: 'Name', direction: 'asc'}}
                 filterable={['ID', 'Name', 'Image', 'Command']}
                 hideFilterInput
                 noDataText="Couldn't find any tasks"

--- a/ui/src/components/services/ServiceListView.js
+++ b/ui/src/components/services/ServiceListView.js
@@ -100,13 +100,13 @@ class ServiceListView extends React.Component {
         <Td column="" className="collapsing">
           <Checkbox checked={selected} onChange={() => { this.selectItem(service.ID) }} />
         </Td>
-        <Td column="Tasks" className="collapsing">
+        <Td column="Tasks" className="collapsing" value={summary.green ? summary.green : "0"}>
           <div>
             {(summary.green ? summary.green : "0")}
             {(service.Spec.Mode.Replicated ? ` / ${service.Spec.Mode.Replicated.Replicas}` : "")}
           </div>
         </Td>
-        <Td column="ID" className="collapsing">
+        <Td column="ID" className="collapsing" value={service.ID}>
           <Link to={`/services/inspect/${service.ID}`}>{service.ID.substring(0, 12)}</Link>
         </Td>
         <Td column="Name">{service.Spec.Name}</Td>
@@ -157,9 +157,10 @@ class ServiceListView extends React.Component {
           <Grid.Column width={16}>
             {error && (<Message error>{JSON.stringify(error)}</Message>)}
             <Table
-              className="ui compact celled sortable unstackable table"
+              className="ui compact celled unstackable table"
               ref="table"
-              sortable
+              sortable={["Tasks", "ID", "Name", "Image"]}
+              defaultSort={{column: 'Name', direction: 'asc'}}
               filterable={["ID", "Name", "Image"]}
               hideFilterInput
               noDataText="Couldn't find any services">

--- a/ui/src/components/volumes/VolumeListView.js
+++ b/ui/src/components/volumes/VolumeListView.js
@@ -81,7 +81,7 @@ class VolumeListView extends React.Component {
           <Checkbox checked={selected} onChange={() => { this.selectItem(volume.Name) }} />
         </Td>
         <Td column="Driver">{volume.Driver}</Td>
-        <Td column="Name"><Link to={`/volumes/inspect/${volume.Name}`}>{volume.Name}</Link></Td>
+        <Td column="Name" value={volume.Name}><Link to={`/volumes/inspect/${volume.Name}`}>{volume.Name}</Link></Td>
         <Td column="Scope">{volume.Scope}</Td>
       </Tr>
     );
@@ -115,8 +115,9 @@ class VolumeListView extends React.Component {
             {error && (<Message error>{error}</Message>)}
             <Table
               ref="table"
-              className="ui compact celled sortable unstackable table"
-              sortable
+              className="ui compact celled unstackable table"
+              sortable={["Driver", "Name", "Scope"]}
+              defaultSort={{column: 'Name', direction: 'asc'}}
               filterable={[]}
               noDataText="Couldn't find any volumes"
             >


### PR DESCRIPTION
PR https://github.com/shipyard/shipyard/pull/952 only fixed the sort icons for `ImageListView` :(

This PR
- applies that fix to all tables
- adds a default sort for all tables
- sets the `value` attribute on `<Td>` elements with complicated contents (so that column can be sorted by this `value`)